### PR TITLE
run dispatch handlers concurrently

### DIFF
--- a/solrmonitor/fifo.go
+++ b/solrmonitor/fifo.go
@@ -41,8 +41,9 @@ func (q *fifoTaskQueue) add(task zkDispatchTask) {
 				}
 			}
 			biggerSlice = make([]zkDispatchTask, newSize)
-			copy(biggerSlice, q.slice[q.head:])
-			copy(biggerSlice[len(q.slice)-q.head:], q.slice[:q.head])
+			leadingSlice, trailingSlice := q.slice[q.head:], q.slice[:q.head]
+			copy(biggerSlice, leadingSlice)
+			copy(biggerSlice[len(leadingSlice):], trailingSlice)
 			q.head = 0
 			q.tail = q.size
 			q.slice = biggerSlice

--- a/solrmonitor/fifo.go
+++ b/solrmonitor/fifo.go
@@ -1,0 +1,79 @@
+package solrmonitor
+
+import "github.com/samuel/go-zookeeper/zk"
+
+// zkDispatchTask is a queued task
+type zkDispatchTask struct {
+	callback ZkEventCallback
+	event    zk.Event
+}
+
+// fifoTaskQueue is a FIFO queue using a ring buffer. A worker goroutine processes elements in
+// a queue. This uses a ring buffer instead of a simpler approach that only uses Go slices
+// (e.g. q = append(q, e) to enqueue; q = q[1:] to dequeue). The simpler approach incurs many more
+// re-allocations of the slice's underlying array whereas the ring buffer approach only grows the
+// array when necessary to store the whole of actively enqueued elements.
+type fifoTaskQueue struct {
+	slice []zkDispatchTask
+	tail  int
+	head  int
+	size  int
+}
+
+// add adds a new item to the queue, potentially growing the underlying ring buffer if necessary.
+func (q *fifoTaskQueue) add(task zkDispatchTask) {
+	if q.head == q.tail {
+		if len(q.slice) == 0 {
+			q.slice = make([]zkDispatchTask, 16)
+		} else if q.size > 0 {
+			// Grow underlying slice. We can't rely on Go's append() for adding to the
+			// queue because that would lead to unbounded storage as the offset is
+			// continually incremented with each poll. So we use a circular buffer, and
+			// thus must manage the growing of the slice ourselves
+			var biggerSlice []zkDispatchTask
+			newSize := len(q.slice) * 2
+			if newSize <= 0 {
+				// overflow really should never happen, but out of an
+				// abundance of caution...
+				newSize = maxInt
+				if q.size >= newSize {
+					panic("cannot grow queue any further!")
+				}
+			}
+			biggerSlice = make([]zkDispatchTask, newSize)
+			copy(biggerSlice, q.slice[q.head:])
+			copy(biggerSlice[len(q.slice)-q.head:], q.slice[:q.head])
+			q.head = 0
+			q.tail = q.size
+			q.slice = biggerSlice
+		}
+	}
+	q.slice[q.tail] = task
+	q.tail = (q.tail + 1) % len(q.slice)
+	q.size++
+}
+
+// pop removes and returns the next item in the queue.
+func (q *fifoTaskQueue) poll() (polled zkDispatchTask, ok bool) {
+	if q.size == 0 {
+		ok = false
+		return
+	} else {
+		polled = q.slice[q.head]
+		ok = true
+	}
+	q.head = (q.head + 1) % len(q.slice)
+	q.size--
+	return
+}
+
+// peek returns the head of the queue. The ok flag will be false if the queue is empty.
+func (q *fifoTaskQueue) peek() (head zkDispatchTask, ok bool) {
+	if q.size == 0 {
+		ok = false
+	} else {
+		head = q.slice[q.head]
+		ok = true
+	}
+	return
+}

--- a/solrmonitor/fifo_test.go
+++ b/solrmonitor/fifo_test.go
@@ -90,6 +90,6 @@ func (g *taskGenerator) newTask() zkDispatchTask {
 	})
 	return zkDispatchTask{
 		callback: &handler,
-		event: zk.Event{Type: zk.EventType(*g)},
+		event:    zk.Event{Type: zk.EventType(*g)},
 	}
 }

--- a/solrmonitor/fifo_test.go
+++ b/solrmonitor/fifo_test.go
@@ -1,12 +1,13 @@
 package solrmonitor
 
 import (
-	"github.com/samuel/go-zookeeper/zk"
-	"k8s.io/kubernetes/staging/src/k8s.io/client-go/pkg/util/rand"
+	"math/rand"
 	"testing"
+
+	"github.com/samuel/go-zookeeper/zk"
 )
 
-func TestSimple(t *testing.T) {
+func TestFifoSimple(t *testing.T) {
 	q := fifoTaskQueue{}
 	var g taskGenerator
 
@@ -30,7 +31,7 @@ func TestSimple(t *testing.T) {
 	}
 }
 
-func TestRingBufferMaintenance(t *testing.T) {
+func TestFifoRingBufferMaintenance(t *testing.T) {
 	// We do lots of operations to make sure we test various cases, like resizing of the
 	// queues buffer, head and tail wrapping past the end of the ring buffer, etc.
 
@@ -84,10 +85,11 @@ type taskGenerator int
 
 func (g *taskGenerator) newTask() zkDispatchTask {
 	(*g)++
+	handler := ZkEventHandler(func(zk.Event) <-chan zk.Event {
+		return nil
+	})
 	return zkDispatchTask{
-		callback: &zkEventHandlerAdapter{func(zk.Event) <-chan zk.Event {
-			return nil
-		}},
+		callback: &handler,
 		event: zk.Event{Type: zk.EventType(*g)},
 	}
 }

--- a/solrmonitor/fifo_test.go
+++ b/solrmonitor/fifo_test.go
@@ -1,0 +1,93 @@
+package solrmonitor
+
+import (
+	"github.com/samuel/go-zookeeper/zk"
+	"k8s.io/kubernetes/staging/src/k8s.io/client-go/pkg/util/rand"
+	"testing"
+)
+
+func TestSimple(t *testing.T) {
+	q := fifoTaskQueue{}
+	var g taskGenerator
+
+	for i := 0; i < 10; i++ {
+		task := g.newTask()
+		q.add(task)
+		if peeked, ok := q.peek(); !ok || !equals(peeked, task) {
+			t.Error("Failed to peek task that was just added")
+		}
+		if polled, ok := q.poll(); !ok || !equals(polled, task) {
+			t.Error("Failed to poll task that was just added")
+		}
+
+		// queue is now empty
+		if _, ok := q.peek(); ok {
+			t.Error("Peek should have failed as queue should now be empty")
+		}
+		if _, ok := q.poll(); ok {
+			t.Error("Poll should have failed as queue should now be empty")
+		}
+	}
+}
+
+func TestRingBufferMaintenance(t *testing.T) {
+	// We do lots of operations to make sure we test various cases, like resizing of the
+	// queues buffer, head and tail wrapping past the end of the ring buffer, etc.
+
+	q := &fifoTaskQueue{}
+	var g taskGenerator
+	removed := 0
+
+	// fill the queue and get it to grow (occasional removals to make sure it works
+	// when the head pointer is not at the beginning of the slice)
+	for q.size < 1000 {
+		if rand.Intn(5) == 0 && q.size > 0 {
+			checkRemove(q, t, &removed)
+		} else {
+			q.add(g.newTask())
+		}
+	}
+
+	// add and remove, to make sure we wrap head and tail around the end of the buffer
+	for i := 0; i < 10*1000; i++ {
+		if i%2 == 0 {
+			q.add(g.newTask())
+		} else {
+			checkRemove(q, t, &removed)
+		}
+	}
+
+	// finally, drain the queue
+	for q.size > 0 {
+		checkRemove(q, t, &removed)
+	}
+}
+
+func equals(task1, task2 zkDispatchTask) bool {
+	// function types are not comparable; we really only need to care about the events
+	return task1.event == task2.event
+}
+
+func checkRemove(q *fifoTaskQueue, t *testing.T, removeCount *int) {
+	task, ok := q.poll()
+	if !ok {
+		t.Fatalf("Polling from queue failed even though size = %d", q.size)
+	}
+	(*removeCount)++
+	if int(task.event.Type) != *removeCount {
+		t.Fatalf("Expecting to have polled %d; instead polled %d",
+			*removeCount, int(task.event.Type))
+	}
+}
+
+type taskGenerator int
+
+func (g *taskGenerator) newTask() zkDispatchTask {
+	(*g)++
+	return zkDispatchTask{
+		callback: &zkEventHandlerAdapter{func(zk.Event) <-chan zk.Event {
+			return nil
+		}},
+		event: zk.Event{Type: zk.EventType(*g)},
+	}
+}

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -25,11 +25,6 @@ import (
 	"github.com/samuel/go-zookeeper/zk"
 )
 
-const (
-	checkTimeout  = 3 * time.Second
-	checkInterval = 10 * time.Millisecond
-)
-
 func createSolrMonitor(t *testing.T) (*zk.Conn, *SolrMonitor, *smtesting.ZkTestLogger, error) {
 	logger := smtesting.NewZkTestLogger(t)
 	connOption := func(c *zk.Conn) { c.SetLogger(logger) }
@@ -44,6 +39,19 @@ func createSolrMonitor(t *testing.T) (*zk.Conn, *SolrMonitor, *smtesting.ZkTestL
 			t.Logf("Global: %s", e)
 		}
 	}()
+
+	// Solrmonitor checks the "clusterstate.json" file in the root node it is given.
+	// So seed that file.
+	_, err = zkCli.Create("/solrmonitortest", []byte{}, 0, zk.WorldACL(zk.PermAll))
+	if err != nil && err != zk.ErrNodeExists {
+		zkCli.Close()
+		return nil, nil, nil, err
+	}
+	_, err = zkCli.Create("/solrmonitortest/clusterstate.json", []byte("{}"), 0, zk.WorldACL(zk.PermAll))
+	if err != nil && err != zk.ErrNodeExists {
+		zkCli.Close()
+		return nil, nil, nil, err
+	}
 
 	sm, err := NewSolrMonitorWithRoot(zkCli, logger, "/solrmonitortest")
 	if err != nil {
@@ -191,89 +199,4 @@ func TestBadStateJson(t *testing.T) {
 
 	shouldError(t, sm, "c1")
 	shouldBecomeEq(t, 1, logger.GetErrorCount)
-}
-
-func shouldBecomeEq(t *testing.T, expected int32, actualFunc func() int32) {
-	var actual int32
-	for end := time.Now().Add(checkTimeout); time.Now().Before(end); {
-		actual = actualFunc()
-		if expected == actual {
-			return // success
-		}
-		time.Sleep(checkInterval)
-	}
-	t.Errorf("expected %d, got: %d", expected, actual)
-}
-
-func shouldExist(t *testing.T, sm *SolrMonitor, name string) {
-	for end := time.Now().Add(checkTimeout); time.Now().Before(end); {
-		collectionState, err := sm.GetCollectionState(name)
-		if err != nil {
-			t.Fatal(err)
-			return
-		}
-		if collectionState != nil {
-			// GetCurrentState should be consistent
-			state, err := sm.GetCurrentState()
-			if err != nil {
-				t.Fatal(err)
-				return
-			}
-			val, ok := state[name]
-			if val == nil || !ok {
-				t.Errorf("expected %s to exist in state map, but it does not", name)
-			}
-			return // success
-		}
-		time.Sleep(checkInterval)
-	}
-	t.Errorf("expected %s to exist, but it does not", name)
-}
-
-func shouldNotExist(t *testing.T, sm *SolrMonitor, name string) {
-	// Wait a moment before checking so we don't false-positive.
-	time.Sleep(200 * time.Millisecond)
-	for end := time.Now().Add(checkTimeout); time.Now().Before(end); {
-		collectionState, err := sm.GetCollectionState(name)
-		if err != nil {
-			t.Fatal(err)
-			return
-		}
-		if collectionState == nil {
-			// GetCurrentState should be consistent
-			state, err := sm.GetCurrentState()
-			if err != nil {
-				t.Fatal(err)
-				return
-			}
-			val, ok := state[name]
-			if val != nil || ok {
-				t.Errorf("expected %s to not exist in state map, but it does", name)
-			}
-			return // success
-		}
-		time.Sleep(checkInterval)
-	}
-	t.Errorf("expected %s to not exist, but it does", name)
-}
-
-func shouldError(t *testing.T, sm *SolrMonitor, name string) {
-	for end := time.Now().Add(checkTimeout); time.Now().Before(end); {
-		_, err := sm.GetCollectionState(name)
-		if err != nil {
-			// GetCurrentState should only silently record an error, however
-			state, err := sm.GetCurrentState()
-			if err != nil {
-				t.Fatal(err)
-				return
-			}
-			val, ok := state[name]
-			if val != nil || ok {
-				t.Errorf("expected %s to not exist in state map, but it does", name)
-			}
-			return // success
-		}
-		time.Sleep(checkInterval)
-	}
-	t.Errorf("expected %s to error, but no error", name)
 }

--- a/solrmonitor/util_test.go
+++ b/solrmonitor/util_test.go
@@ -1,0 +1,98 @@
+package solrmonitor
+
+import (
+	"testing"
+	"time"
+)
+
+// Utility functions used by tests
+
+const (
+	checkTimeout  = 3 * time.Second
+	checkInterval = 10 * time.Millisecond
+)
+
+func shouldBecomeEq(t *testing.T, expected int32, actualFunc func() int32) {
+	var actual int32
+	for end := time.Now().Add(checkTimeout); time.Now().Before(end); {
+		actual = actualFunc()
+		if expected == actual {
+			return // success
+		}
+		time.Sleep(checkInterval)
+	}
+	t.Errorf("expected %d, got: %d", expected, actual)
+}
+
+func shouldExist(t *testing.T, sm *SolrMonitor, name string) {
+	for end := time.Now().Add(checkTimeout); time.Now().Before(end); {
+		collectionState, err := sm.GetCollectionState(name)
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+		if collectionState != nil {
+			// GetCurrentState should be consistent
+			state, err := sm.GetCurrentState()
+			if err != nil {
+				t.Fatal(err)
+				return
+			}
+			val, ok := state[name]
+			if val == nil || !ok {
+				t.Errorf("expected %s to exist in state map, but it does not", name)
+			}
+			return // success
+		}
+		time.Sleep(checkInterval)
+	}
+	t.Errorf("expected %s to exist, but it does not", name)
+}
+
+func shouldNotExist(t *testing.T, sm *SolrMonitor, name string) {
+	// Wait a moment before checking so we don't false-positive.
+	time.Sleep(200 * time.Millisecond)
+	for end := time.Now().Add(checkTimeout); time.Now().Before(end); {
+		collectionState, err := sm.GetCollectionState(name)
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+		if collectionState == nil {
+			// GetCurrentState should be consistent
+			state, err := sm.GetCurrentState()
+			if err != nil {
+				t.Fatal(err)
+				return
+			}
+			val, ok := state[name]
+			if val != nil || ok {
+				t.Errorf("expected %s to not exist in state map, but it does", name)
+			}
+			return // success
+		}
+		time.Sleep(checkInterval)
+	}
+	t.Errorf("expected %s to not exist, but it does", name)
+}
+
+func shouldError(t *testing.T, sm *SolrMonitor, name string) {
+	for end := time.Now().Add(checkTimeout); time.Now().Before(end); {
+		_, err := sm.GetCollectionState(name)
+		if err != nil {
+			// GetCurrentState should only silently record an error, however
+			state, err := sm.GetCurrentState()
+			if err != nil {
+				t.Fatal(err)
+				return
+			}
+			val, ok := state[name]
+			if val != nil || ok {
+				t.Errorf("expected %s to not exist in state map, but it does", name)
+			}
+			return // success
+		}
+		time.Sleep(checkInterval)
+	}
+	t.Errorf("expected %s to error, but no error", name)
+}

--- a/solrmonitor/zkdispatcher_test.go
+++ b/solrmonitor/zkdispatcher_test.go
@@ -1,0 +1,214 @@
+package solrmonitor
+
+import (
+	"github.com/samuel/go-zookeeper/zk"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// simple generator of zk.Event objects, with monotonically increasing Type field
+type eventGenerator int32
+
+func (g *eventGenerator) newEvent() zk.Event {
+	e := atomic.AddInt32((*int32)(g), 1)
+	return zk.Event{Type: zk.EventType(e)}
+}
+
+// state used and tracked throughout each test case
+type testState struct {
+	t *testing.T
+	// generator of events, for submitting an event to fire the re-registered watch
+	gen eventGenerator
+	// completes when the callback is done and no longer re-registering itself
+	done sync.WaitGroup
+	// number of concurrent executions
+	numConcurrentExecutions int32
+	// maximum number of concurrent executions observed
+	maxConcurrentExecutions int32
+	// optional wait group used to let watcher go routines start
+	ready *sync.WaitGroup
+	// optional wait group used to coordinate the start of handling
+	run *sync.WaitGroup
+	// if true, assume events are consumed perfectly in order (e.g. event #1 is the first
+	// event handled, event #2 is the second, and so on)
+	assumeEventOrder bool
+}
+
+func (state *testState) newCallback(maxEvents int32) *testCallback {
+	if state.ready != nil {
+		state.ready.Add(1)
+	}
+	return &testCallback{
+		state:        state,
+		maxNumEvents: maxEvents,
+		ready:        state.ready,
+		run:          state.run,
+	}
+}
+
+// callback for testing dispatches
+type testCallback struct {
+	state *testState
+	// number of events processed
+	numEvents int32
+	// maximum number of events to process, after which the callback no longer re-registers
+	// itself
+	maxNumEvents int32
+	// if non-nil, mark this as done at the start of first callback (to indicate that the
+	// callback is ready to start)
+	ready *sync.WaitGroup
+	// if non-nil, wait on this before starting first callback (to coordinate the start of
+	// multiple callbacks)
+	run *sync.WaitGroup
+}
+
+func (cb *testCallback) Handle(e zk.Event) <-chan zk.Event {
+	// track the maximum number of concurrent executions
+	num := atomic.AddInt32(&cb.state.numConcurrentExecutions, 1)
+	defer atomic.AddInt32(&cb.state.numConcurrentExecutions, -1)
+
+	// if these wait groups are non-nil, we are coordinating the start of handling
+	if cb.ready != nil {
+		cb.ready.Done()
+		cb.ready = nil
+	}
+	if cb.run != nil {
+		cb.run.Wait()
+		cb.run = nil
+	}
+
+	for {
+		max := atomic.LoadInt32(&cb.state.maxConcurrentExecutions)
+		if num <= max {
+			break
+		}
+		if num > max &&
+			atomic.CompareAndSwapInt32(&cb.state.maxConcurrentExecutions, max, num) {
+			break
+		}
+	}
+
+	numEvents := atomic.AddInt32(&cb.numEvents, 1)
+	if cb.state.assumeEventOrder && e.Type != zk.EventType(numEvents) {
+		cb.state.t.Errorf("Expecting event %d, got %d", numEvents, int(e.Type))
+	}
+
+	if numEvents >= cb.maxNumEvents {
+		cb.state.done.Done()
+		return nil
+	} else {
+		ch := make(chan zk.Event, 1)
+		ch <- cb.state.gen.newEvent()
+		return ch
+	}
+}
+
+func TestReregistration(t *testing.T) {
+	disp := NewZkDispatcher(zk.DefaultLogger)
+
+	state := testState{t: t, assumeEventOrder: true}
+	cb := state.newCallback(100)
+	state.done.Add(1)
+
+	channel := make(chan zk.Event, 1)
+	disp.WatchEvent(channel, cb)
+
+	channel <- state.gen.newEvent()
+	state.done.Wait()
+
+	if cb.numEvents != 100 {
+		t.Errorf("Should have processed 100 events but instead processed %d", cb.numEvents)
+	}
+
+	tasksShouldBecomeEmpty(t, disp)
+}
+
+func TestDispatchesToSameCallbackAreSerial(t *testing.T) {
+	disp := NewZkDispatcher(zk.DefaultLogger)
+	var channels [10]chan zk.Event
+	var run sync.WaitGroup
+	run.Add(1)
+
+	state := testState{t: t, run: &run}
+	cb := state.newCallback(10)
+
+	for i := 0; i < 10; i++ {
+		state.done.Add(1)
+		channels[i] = make(chan zk.Event, 1)
+		disp.WatchEvent(channels[i], cb)
+	}
+
+	// send an event to get them started
+	for i := 0; i < 10; i++ {
+		channels[i] <- state.gen.newEvent()
+	}
+	// give dispatch go routine(s) a chance to start
+	time.Sleep(200 * time.Millisecond)
+	// let 'em rip
+	run.Done()
+
+	// wait for them all to finish
+	state.done.Wait()
+
+	if state.maxConcurrentExecutions != 1 {
+		t.Errorf("Executions should be serial, but detected %d concurrent exceutions",
+			state.maxConcurrentExecutions)
+	}
+
+	tasksShouldBecomeEmpty(t, disp)
+}
+
+func TestDispatchesToDifferentCallbacksAreConcurrent(t *testing.T) {
+	// make sure we can run all of these concurrently
+	numRoutines := runtime.GOMAXPROCS(0)
+	if numRoutines < 30 {
+		numRoutines = runtime.GOMAXPROCS(30)
+	}
+	defer runtime.GOMAXPROCS(numRoutines)
+
+	disp := NewZkDispatcher(zk.DefaultLogger)
+	var channels [10]chan zk.Event
+	var run, ready sync.WaitGroup
+	run.Add(1)
+
+	state := testState{t: t, run: &run, ready: &ready}
+	var callbacks [10]*testCallback
+	for i := 0; i < 10; i++ {
+		callbacks[i] = state.newCallback(10)
+		state.done.Add(1)
+		channels[i] = make(chan zk.Event, 1)
+		disp.WatchEvent(channels[i], callbacks[i])
+	}
+
+	// send an event to get them started
+	for i := 0; i < 10; i++ {
+		channels[i] <- state.gen.newEvent()
+	}
+
+	// make sure they are all ready
+	ready.Wait()
+	// let 'em rip
+	run.Done()
+
+	// wait for them all to finish
+	state.done.Wait()
+
+	if state.maxConcurrentExecutions != 10 {
+		t.Errorf("Should have been 10 concurrent executions (1 for each callback);"+
+			" instead detected %d", state.maxConcurrentExecutions)
+	}
+
+	tasksShouldBecomeEmpty(t, disp)
+}
+
+func tasksShouldBecomeEmpty(t *testing.T, disp *ZkDispatcher) {
+	// make sure that map of tasks gets cleaned up and returns to empty
+	shouldBecomeEq(t, 0, func() int32 {
+		disp.taskMu.Lock()
+		defer disp.taskMu.Unlock()
+		return int32(len(disp.tasks))
+	})
+}

--- a/solrmonitor/zkdispatcher_test.go
+++ b/solrmonitor/zkdispatcher_test.go
@@ -1,12 +1,12 @@
 package solrmonitor
 
 import (
-	"github.com/samuel/go-zookeeper/zk"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/samuel/go-zookeeper/zk"
 )
 
 // simple generator of zk.Event objects, with monotonically increasing Type field
@@ -162,13 +162,6 @@ func TestDispatchesToSameCallbackAreSerial(t *testing.T) {
 }
 
 func TestDispatchesToDifferentCallbacksAreConcurrent(t *testing.T) {
-	// make sure we can run all of these concurrently
-	numRoutines := runtime.GOMAXPROCS(0)
-	if numRoutines < 30 {
-		numRoutines = runtime.GOMAXPROCS(30)
-	}
-	defer runtime.GOMAXPROCS(numRoutines)
-
 	disp := NewZkDispatcher(zk.DefaultLogger)
 	var channels [10]chan zk.Event
 	var run, ready sync.WaitGroup


### PR DESCRIPTION
This should alleviate issues where the main channel (used to notify the event loop of a new watcher) becomes full. The event loop does much less work, so should have a much easier time keeping up with incoming requests. The actual processing is done in other goroutines.

This branch ensures serial delivery of events to a single callback. However, that was not actually necessary for any existing solrmonitor code because a single "callback" was just a handler for a single node/watch. And since watches are one-shot, events are guaranteed to be serial because a second event cannot be dispatched until after the first one is consumed and the handler re-registers itself. (I believe this code used to use a different goroutine per watch anyway, so the handlers are appropriately "thread-safe".)

I added several new tests to make sure things work. And to make sure solrmonitor's handlers weren't relying on the single goroutine for safety, I ran the tests many times in a loop with the race detector enabled to make sure there were no failures:
```bash
while go test -race -tags integration ./solrmonitor/; do true; done
```
