### PR TITLE
cleanup queue entries after use

### DIFF
--- a/solrmonitor/fifo.go
+++ b/solrmonitor/fifo.go
@@ -61,6 +61,10 @@ func (q *fifoTaskQueue) poll() (polled zkDispatchTask, ok bool) {
 		return
 	} else {
 		polled = q.slice[q.head]
+		// clear the entry in the queue so we don't leak references to
+		// things like the callback (and also allow strings in the event
+		// to be promptly GCed)
+		q.slice[q.head] = zkDispatchTask{}
 		ok = true
 	}
 	q.head = (q.head + 1) % len(q.slice)

--- a/solrmonitor/fifo_test.go
+++ b/solrmonitor/fifo_test.go
@@ -62,11 +62,23 @@ func TestFifoRingBufferMaintenance(t *testing.T) {
 	for q.size > 0 {
 		checkRemove(q, t, &removed)
 	}
+
+	// ensure that we don't leak any references in underlying slice after removing from queue
+	for idx, task := range q.slice {
+		if !isEmpty(task) {
+			t.Errorf("Entry in queue at index %d was not cleared: %v", idx, task)
+		}
+	}
 }
 
 func equals(task1, task2 zkDispatchTask) bool {
 	// function types are not comparable; we really only need to care about the events
 	return task1.event == task2.event
+}
+
+func isEmpty(task zkDispatchTask) bool {
+	var empty zkDispatchTask
+	return equals(empty, task)
 }
 
 func checkRemove(q *fifoTaskQueue, t *testing.T, removeCount *int) {


### PR DESCRIPTION
This addresses a possible memory leak in the fifo queue.

Note that this isn't typically urgent in practice because once a queue quiesces, the dispatcher removes it completely (so the whole queue, and any possible remaining references, can be GCed).

But if there are a lot of workers and one or more queues start to get large-ish, this will ensure the process won't prematurely OOME.