### PR TITLE
Added per replica state (PRS ) protocol

### DIFF
--- a/solrcheck/problems_test.go
+++ b/solrcheck/problems_test.go
@@ -31,17 +31,17 @@ func TestFindClusterProblems(t *testing.T) {
 	zkState := fakeZk{}
 
 	for collName, coll := range data.ClusterState {
-		collState := &solrmonitor.CollectionState{Shards: map[string]solrmonitor.ShardState{}}
+		collState := &solrmonitor.CollectionState{Shards: map[string]*solrmonitor.ShardState{}}
 		clusterState[collName] = collState
 		for shardName, shard := range coll {
-			shardState := solrmonitor.ShardState{
+			shardState := &solrmonitor.ShardState{
 				State:    shard.State,
 				Range:    shard.HashRange,
-				Replicas: map[string]solrmonitor.ReplicaState{},
+				Replicas: map[string]*solrmonitor.ReplicaState{},
 			}
 			collState.Shards[shardName] = shardState
 			for replicaName, replica := range shard.Replicas {
-				replicaState := solrmonitor.ReplicaState{
+				replicaState := &solrmonitor.ReplicaState{
 					State:    replica.State,
 					Core:     replica.Core,
 					BaseUrl:  replica.BaseURL,

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -32,7 +32,7 @@ type CollectionState struct {
 }
 
 func (cs *CollectionState) String() string {
-	return fmt.Sprintf("CollectionState{Shards:%+v, PerReplicaState:%s}", cs.Shards, cs.PerReplicaState)
+	return fmt.Sprintf("CollectionState\n{Shards:%+v, PerReplicaState:%s}\n", cs.Shards, cs.PerReplicaState)
 }
 
 type Router struct {

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -14,6 +14,8 @@
 
 package solrmonitor
 
+import "fmt"
+
 type CollectionState struct {
 	Shards            map[string]*ShardState `json:"shards"`            // map from shard name to shard state
 	ReplicationFactor string                 `json:"replicationFactor"` // e.g. "1" (yes, these are strings, not numbers)
@@ -27,6 +29,10 @@ type CollectionState struct {
 	ConfigName      string `json:"configName,omitempty"`   // the name of the node in solr/configs (in ZK) that this collection uses
 	ZkNodeVersion   int32  `json:"znodeVersion,omitempty"` // the ZK node version this state snapshot represents
 	PerReplicaState string `json:"perReplicaState"`        // whether collection keeps state for each replica separately
+}
+
+func (cs *CollectionState) String() string {
+	return fmt.Sprintf("CollectionState{Shards:%+v, PerReplicaState:%s}", cs.Shards, cs.PerReplicaState)
 }
 
 type Router struct {

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -15,20 +15,31 @@
 package solrmonitor
 
 type CollectionState struct {
-	Shards            map[string]ShardState `json:"shards"`            // map from shard name to shard state
-	ReplicationFactor string                `json:"replicationFactor"` // e.g. "1" (yes, these are strings, not numbers)
-	Router            Router                `json:"router"`            // e.g. {"name":"compositeId"}
-	MaxShardsPerNode  string                `json:"maxShardsPerNode"`  // e.g. "1" (yes, these are strings, not numbers)
-	AutoAddReplicas   string                `json:"autoAddReplicas"`   // e.g. "false" (yes, these are strings, not bools)
+	Shards            map[string]*ShardState `json:"shards"`            // map from shard name to shard state
+	ReplicationFactor string                 `json:"replicationFactor"` // e.g. "1" (yes, these are strings, not numbers)
+	Router            Router                 `json:"router"`            // e.g. {"name":"compositeId"}
+	MaxShardsPerNode  string                 `json:"maxShardsPerNode"`  // e.g. "1" (yes, these are strings, not numbers)
+	AutoAddReplicas   string                 `json:"autoAddReplicas"`   // e.g. "false" (yes, these are strings, not bools)
 
 	// These fields are synthetic. They ARE present in COLLECTIONSTATUS response in
 	// solr collection API, but they are NOT in state.json docs in Zookeeper.
 
 	ConfigName      string `json:"configName,omitempty"`   // the name of the node in solr/configs (in ZK) that this collection uses
 	ZkNodeVersion   int32  `json:"znodeVersion,omitempty"` // the ZK node version this state snapshot represents
-	PerReplicaState bool   `json:"per_replica_state"`      // whether collection keeps state for each replica separately
+	PerReplicaState string `json:"perReplicaState"`        // whether collection keeps state for each replica separately
 }
 
 type Router struct {
 	Name string `json:"name"` // e.g. "compositeId"
+}
+
+type PerReplicaState struct {
+	// name of the replica
+	Name string `json:"name"`
+	// replica's state version
+	Version int32 `json:"version"`
+	// is replica active
+	State string `json:"state"`
+	// If "true", this replica is the shard leader
+	Leader string `json:"leader,omitempty"`
 }

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -26,6 +26,7 @@ type CollectionState struct {
 
 	ConfigName    string `json:"configName,omitempty"`   // the name of the node in solr/configs (in ZK) that this collection uses
 	ZkNodeVersion int32  `json:"znodeVersion,omitempty"` // the ZK node version this state snapshot represents
+	PerReplicaState bool `json:"per_replica_state"` // whether collection keeps state for each replica separately
 }
 
 type Router struct {

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -24,9 +24,9 @@ type CollectionState struct {
 	// These fields are synthetic. They ARE present in COLLECTIONSTATUS response in
 	// solr collection API, but they are NOT in state.json docs in Zookeeper.
 
-	ConfigName    string `json:"configName,omitempty"`   // the name of the node in solr/configs (in ZK) that this collection uses
-	ZkNodeVersion int32  `json:"znodeVersion,omitempty"` // the ZK node version this state snapshot represents
-	PerReplicaState bool `json:"per_replica_state"` // whether collection keeps state for each replica separately
+	ConfigName      string `json:"configName,omitempty"`   // the name of the node in solr/configs (in ZK) that this collection uses
+	ZkNodeVersion   int32  `json:"znodeVersion,omitempty"` // the ZK node version this state snapshot represents
+	PerReplicaState bool   `json:"per_replica_state"`      // whether collection keeps state for each replica separately
 }
 
 type Router struct {

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -35,6 +35,10 @@ func (cs *CollectionState) String() string {
 	return fmt.Sprintf("CollectionState\n{Shards:%+v, PerReplicaState:%s}\n", cs.Shards, cs.PerReplicaState)
 }
 
+func (cs *CollectionState) isPRSEnabled() bool {
+	return cs.PerReplicaState == "true"
+}
+
 type Router struct {
 	Name string `json:"name"` // e.g. "compositeId"
 }

--- a/solrmonitor/mock.go
+++ b/solrmonitor/mock.go
@@ -4,9 +4,7 @@ func NewMockSolrMonitor(state ClusterState, liveNodes []string) *SolrMonitor {
 	collections := map[string]*collection{}
 	for k, v := range state {
 		collections[k] = &collection{
-			cachedState: &parsedCollectionState{
 				collectionState: v,
-			},
 		}
 	}
 	return &SolrMonitor{

--- a/solrmonitor/mock.go
+++ b/solrmonitor/mock.go
@@ -4,7 +4,7 @@ func NewMockSolrMonitor(state ClusterState, liveNodes []string) *SolrMonitor {
 	collections := map[string]*collection{}
 	for k, v := range state {
 		collections[k] = &collection{
-				collectionState: v,
+			collectionState: v,
 		}
 	}
 	return &SolrMonitor{

--- a/solrmonitor/replicastate.go
+++ b/solrmonitor/replicastate.go
@@ -26,7 +26,7 @@ type ReplicaState struct {
 }
 
 func (s *ReplicaState) String() string {
-	return fmt.Sprintf("ReplicaState{Core:%s, BaseUrl:%s, NodeName=%s, State=%s, Leader=%s, Version=%d}", s.Core, s.BaseUrl, s.NodeName, s.State, s.Leader, s.Version)
+	return fmt.Sprintf("\nReplicaState{Core:%s, BaseUrl:%s, NodeName=%s, State=%s, Leader=%s, Version=%d}\n", s.Core, s.BaseUrl, s.NodeName, s.State, s.Leader, s.Version)
 }
 
 func (r ReplicaState) IsActive() bool {

--- a/solrmonitor/replicastate.go
+++ b/solrmonitor/replicastate.go
@@ -20,6 +20,7 @@ type ReplicaState struct {
 	NodeName string `json:"node_name"` // e.g. "10.240.110.3:8983_solr"
 	State    string `json:"state"`     // e.g. "active", "inactive", "down", "recovering"
 	Leader   string `json:"leader"`    // e.g. "true" or "false" (yes, these are strings, not bools)
+	Version  int32  `json:"version"`   // e.g. "1" version of replica state
 }
 
 func (r ReplicaState) IsActive() bool {

--- a/solrmonitor/replicastate.go
+++ b/solrmonitor/replicastate.go
@@ -25,8 +25,8 @@ type ReplicaState struct {
 	Version  int32  `json:"version"`   // e.g. "1" version of replica state
 }
 
-func (s *ReplicaState) String() string {
-	return fmt.Sprintf("\nReplicaState{Core:%s, BaseUrl:%s, NodeName=%s, State=%s, Leader=%s, Version=%d}\n", s.Core, s.BaseUrl, s.NodeName, s.State, s.Leader, s.Version)
+func (r *ReplicaState) String() string {
+	return fmt.Sprintf("\nReplicaState{Core:%s, BaseUrl:%s, NodeName=%s, State=%s, Leader=%s, Version=%d}\n", r.Core, r.BaseUrl, r.NodeName, r.State, r.Leader, r.Version)
 }
 
 func (r ReplicaState) IsActive() bool {

--- a/solrmonitor/replicastate.go
+++ b/solrmonitor/replicastate.go
@@ -14,6 +14,8 @@
 
 package solrmonitor
 
+import "fmt"
+
 type ReplicaState struct {
 	Core     string `json:"core"`      // e.g. "delta_shard1_replica1"
 	BaseUrl  string `json:"base_url"`  // e.g. "http://10.240.110.3:8983/solr"
@@ -21,6 +23,10 @@ type ReplicaState struct {
 	State    string `json:"state"`     // e.g. "active", "inactive", "down", "recovering"
 	Leader   string `json:"leader"`    // e.g. "true" or "false" (yes, these are strings, not bools)
 	Version  int32  `json:"version"`   // e.g. "1" version of replica state
+}
+
+func (s *ReplicaState) String() string {
+	return fmt.Sprintf("ReplicaState{Core:%s, BaseUrl:%s, NodeName=%s, State=%s, Leader=%s, Version=%d}", s.Core, s.BaseUrl, s.NodeName, s.State, s.Leader, s.Version)
 }
 
 func (r ReplicaState) IsActive() bool {

--- a/solrmonitor/shardstate.go
+++ b/solrmonitor/shardstate.go
@@ -38,6 +38,10 @@ type bounds struct {
 	err error
 }
 
+func (ss *ShardState) String() string {
+	return fmt.Sprintf("ShardState{Range:%s, State:%s, Replicas=%+v, rangeBounds=%+v}", ss.Range, ss.State, ss.Replicas, ss.rangeBounds)
+}
+
 func (s ShardState) IsActive() bool {
 	return s.State == "active"
 }

--- a/solrmonitor/shardstate.go
+++ b/solrmonitor/shardstate.go
@@ -23,10 +23,10 @@ import (
 )
 
 type ShardState struct {
-	Parent   string                  `json:"parent"`
-	Range    string                  `json:"range"` // e.g. "80000000-b332ffff"
-	State    string                  `json:"state"` // e.g. "active", "inactive"
-	Replicas map[string]ReplicaState `json:"replicas,omitempty"`
+	Parent   string                   `json:"parent"`
+	Range    string                   `json:"range"` // e.g. "80000000-b332ffff"
+	State    string                   `json:"state"` // e.g. "active", "inactive"
+	Replicas map[string]*ReplicaState `json:"replicas,omitempty"`
 
 	rangeBounds      bounds
 	rangeInitialized bool

--- a/solrmonitor/shardstate.go
+++ b/solrmonitor/shardstate.go
@@ -38,8 +38,8 @@ type bounds struct {
 	err error
 }
 
-func (ss *ShardState) String() string {
-	return fmt.Sprintf("\nShardState{Range:%s, State:%s, Replicas=%+v, rangeBounds=%+v}\n", ss.Range, ss.State, ss.Replicas, ss.rangeBounds)
+func (s *ShardState) String() string {
+	return fmt.Sprintf("\nShardState{Range:%s, State:%s, Replicas=%+v, rangeBounds=%+v}\n", s.Range, s.State, s.Replicas, s.rangeBounds)
 }
 
 func (s ShardState) IsActive() bool {

--- a/solrmonitor/shardstate.go
+++ b/solrmonitor/shardstate.go
@@ -39,7 +39,7 @@ type bounds struct {
 }
 
 func (ss *ShardState) String() string {
-	return fmt.Sprintf("ShardState{Range:%s, State:%s, Replicas=%+v, rangeBounds=%+v}", ss.Range, ss.State, ss.Replicas, ss.rangeBounds)
+	return fmt.Sprintf("\nShardState{Range:%s, State:%s, Replicas=%+v, rangeBounds=%+v}\n", ss.Range, ss.State, ss.Replicas, ss.rangeBounds)
 }
 
 func (s ShardState) IsActive() bool {

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -175,7 +175,7 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 }
 
 func (c *SolrMonitor) updateCollectionState(path string, children []string) error {
-	c.logger.Printf("updateCollectionState: children %s", children )
+	c.logger.Printf("Hitesh:updateCollectionState: children %s", children )
 	coll := c.getCollFromPath(path)
 	if coll == nil || len(children) == 0 {
 		//looks like we have not got the collection event yet; it  should be safe to ignore it
@@ -217,7 +217,7 @@ func (c *SolrMonitor) updateCollectionState(path string, children []string) erro
 
 		rmap[prs.Name] = prs
 	}
-
+	c.logger.Printf("Hitesh:updateCollectionState PRS %+v", rmap)
 	coll.parent.mu.Lock()
 	defer coll.parent.mu.Unlock()
 	//update the collection state based on new PRS (per replica state)
@@ -232,6 +232,7 @@ func (c *SolrMonitor) updateCollectionState(path string, children []string) erro
 				}
 			}
 		}
+		c.logger.Printf("Hitesh:updateCollectionState collection added %+v", shard)
 	}
 
 	return nil
@@ -357,7 +358,7 @@ func (c *SolrMonitor) updateCollections(collections []string) error {
 			}
 		}
 	}()
-
+	c.logger.Printf("Hitesh:updateCollections collection added %s", added)
 	// Now start any new collections.
 	var errCount int32
 	var wg sync.WaitGroup
@@ -463,11 +464,13 @@ func (coll *collection) setData(data string, version int32) {
 	defer coll.mu.Unlock()
 	// we need to parse data here as we need to know PRS is enable for collection ot not; if enable then keep watch on coll/state.json children
 	newState := parseStateData(coll.name, []byte(data), coll.zkNodeVersion)
+	coll.parent.logger.Printf("Hitesh:setData collection newstate %+v", newState)
 	var oldState *CollectionState = nil
 	if coll.cachedState != nil {
 		oldState = coll.cachedState.collectionState
 	}
 	coll.updateReplicaVersionAndState(newState.collectionState, oldState)
+	coll.parent.logger.Printf("Hitesh:setData collection updated newstate %+v", newState)
 	coll.zkNodeVersion = version
 	coll.cachedState = newState
 }

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -478,7 +478,7 @@ func (coll *collection) setData(data string, version int32) {
 }
 
 func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, oldState *CollectionState) {
-	if oldState == nil || newState == nil {
+	if oldState == nil || newState == nil || newState.PerReplicaState == "false" {
 		return
 	}
 	for shradName, newShardState := range newState.Shards {

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -145,6 +145,7 @@ func (c *SolrMonitor) doGetCollectionState(name string) (*CollectionState, error
 	if coll == nil {
 		return nil, nil
 	}
+
 	return coll.GetData()
 }
 
@@ -165,8 +166,7 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 	case c.solrRoot + "/live_nodes":
 		return c.updateLiveNodes(children)
 	default:
-		return fmt.Errorf("solrmonitor: unknown childrenChanged: %s", path)
-		//collectionsPath + "/" + coll.name + "/state.json"
+		//collectionsPath + "/" + coll.name + "/state.json": we want to state.json children
 		if !strings.HasPrefix(path, c.solrRoot+"/collections/") || !strings.HasSuffix(path, "/state.json") {
 			return fmt.Errorf("solrmonitor: unknown childrenChanged: %s", path)
 		}
@@ -175,84 +175,77 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 }
 
 func (c *SolrMonitor) updateCollectionState(path string, children []string) error {
+	c.logger.Printf("updateCollectionState: children %s", children )
 	coll := c.getCollFromPath(path)
 	if coll == nil || len(children) == 0 {
 		//looks like we have not got the collection event yet; it  should be safe to ignore it
 		return nil
 	}
 
-	rmap := map[string][]string{}
+	rmap := map[string]*PerReplicaState{}
 
-	for i, r := range children {
+	for _, r := range children {
 		d := strings.Split(r, ":")
-		newv, _ := strconv.ParseInt(d[1], 10, 32)
+		version, _ := strconv.ParseInt(d[1], 10, 32)
 
-		if oldrs, found := rmap[d[0]]; found {
-			oldv, _ := strconv.ParseInt(oldrs[1], 10, 32)
-			if oldv > newv {
+		prs := &PerReplicaState{
+			Name:    d[0],
+			Version: int32(version),
+		}
+
+		if d[2] == "A" {
+			prs.State = "active"
+		} else if d[2] == "D" {
+			prs.State = "down"
+		} else if d[2] == "R" {
+			prs.State = "recovering"
+		} else {
+			prs.State = "inactive"
+		}
+
+		prs.Leader = "false"
+		if len(d) == 4 {
+			prs.Leader = "true"
+		}
+
+		//keep ths latest prs
+		if currentPrs, found := rmap[prs.Name]; found {
+			if currentPrs.Version >= prs.Version {
 				continue
 			}
 		}
 
-		rmap[d[0]] = d
-		//its a bit hack to keep original data string as it is to pass downstream
-		d[0] = children[i]
+		rmap[prs.Name] = prs
 	}
 
 	coll.parent.mu.Lock()
 	defer coll.parent.mu.Unlock()
-
-	add := []string{}
-
+	//update the collection state based on new PRS (per replica state)
 	for _, shard := range coll.cachedState.collectionState.Shards {
-		replicaRemoved := []string{}
-		for lrn, lrs := range shard.Replicas {
-			if rs, found := rmap[lrn]; found {
-				v, _ := strconv.ParseInt(rs[1], 10, 32)
-				if v < int64(lrs.Version) {
-					panic(fmt.Sprintf("Collection {%s} replica %s status version %d should be greator than existing version %d ", coll.name, rs[1], lrs.Version, v))
-				}
+		for rname, rstate := range shard.Replicas {
+			if prs, found := rmap[rname]; found {
 				//if version is more than current then take that state
-				if int32(v) > lrs.Version {
-					lrs.Version = int32(v)
-
-					if rs[2] == "A" {
-						lrs.State = "active"
-					} else if rs[2] == "D" {
-						lrs.State = "down"
-					} else if rs[2] == "R" {
-						lrs.State = "recovering"
-					} else {
-						lrs.State = "inactive"
-					}
-
-					lrs.Leader = "false"
-					if len(rs) == 4 {
-						lrs.Leader = "true"
-					}
-
-					add = append(add, rs[0])
+				if prs.Version > rstate.Version {
+					rstate.Version = prs.Version
+					rstate.Leader = prs.Leader
+					rstate.State = prs.State
 				}
-			} else {
-				replicaRemoved = append(replicaRemoved, lrn)
-			}
-		}
-		if len(replicaRemoved) > 0 {
-			for _, replica := range replicaRemoved {
-				delete(shard.Replicas, replica)
 			}
 		}
 	}
+
 	return nil
 }
 
 func (c *SolrMonitor) shouldWatchChildren(path string) bool {
+	c.logger.Printf("shouldWatchChildren: path [%s]", path)
 	switch path {
 	case c.solrRoot + "/collections":
 		return true
 	case c.solrRoot + "/live_nodes":
 		return true
 	default:
+		// watch coll/state.json childrens for replica status
 		if strings.HasPrefix(path, c.solrRoot+"/collections/") && strings.HasSuffix(path, "/state.json") {
 			return true
 		}
@@ -268,8 +261,25 @@ func (c *SolrMonitor) dataChanged(path string, data string, version int32) error
 	coll := c.getCollFromPath(path)
 	if coll != nil {
 		coll.setData(data, version)
+		coll.startMonitoringReplicaStatus()
 	}
 	return nil
+}
+
+func (coll *collection) startMonitoringReplicaStatus() {
+	coll.mu.Lock()
+	defer coll.mu.Unlock()
+
+	path := coll.parent.solrRoot + "/collections/" + coll.name + "/state.json"
+
+	// TODO: need to revisit coll.isWatched flag(if zk disconnects?). we need to create watch once only Scott?
+	if coll.cachedState.collectionState != nil && !coll.isWatched && coll.cachedState.collectionState.PerReplicaState == "true" {
+		err := coll.parent.zkWatcher.MonitorChildren(path)
+		if err == nil {
+			coll.parent.logger.Printf("startMonitoringReplicaStatus: watching collection [%s] children for PRS", coll.name)
+			coll.isWatched = true
+		}
+	}
 }
 
 func (c *SolrMonitor) shouldWatchData(path string) bool {
@@ -392,11 +402,11 @@ func (c *SolrMonitor) updateLiveNodes(liveNodes []string) error {
 type collection struct {
 	mu            sync.RWMutex
 	name          string       // the name of the collection
-	stateData     string       // the current state.json data, or empty if no state.json node exists
 	zkNodeVersion int32        // the version of the state.json data, or -1 if no state.json node exists
 	parent        *SolrMonitor // if nil, this collection object was removed from the ClusterState
 
 	cachedState *parsedCollectionState // cached of the current parsed stateData if non-nil
+	isWatched   bool
 }
 
 type parsedCollectionState struct {
@@ -411,21 +421,6 @@ func (coll *collection) GetData() (*CollectionState, error) {
 		defer coll.mu.RUnlock()
 		return coll.cachedState
 	}()
-
-	if cachedState == nil {
-		cachedState = func() *parsedCollectionState {
-			coll.mu.Lock()
-			defer coll.mu.Unlock()
-
-			// Could have been initialized in between our first read and getting the write lock.
-			if coll.cachedState == nil {
-				coll.cachedState = parseStateData(coll.name, []byte(coll.stateData), coll.zkNodeVersion)
-			}
-
-			return coll.cachedState
-		}()
-	}
-
 	return cachedState.collectionState, cachedState.err
 }
 
@@ -457,11 +452,6 @@ func parseStateData(name string, data []byte, version int32) *parsedCollectionSt
 
 func (coll *collection) start() error {
 	path := coll.parent.solrRoot + "/collections/" + coll.name + "/state.json"
-	//look for childern as well
-	err := coll.parent.zkWatcher.MonitorData(path)
-	if err != nil {
-		return err
-	}
 	return coll.parent.zkWatcher.MonitorData(path)
 }
 
@@ -471,15 +461,19 @@ func (coll *collection) setData(data string, version int32) {
 	}
 	coll.mu.Lock()
 	defer coll.mu.Unlock()
-	newState := parseStateData(coll.name, []byte(coll.stateData), coll.zkNodeVersion)
-	coll.updateReplicaVersionAndState(newState.collectionState, coll.cachedState.collectionState)
-	coll.stateData = data
+	// we need to parse data here as we need to know PRS is enable for collection ot not; if enable then keep watch on coll/state.json children
+	newState := parseStateData(coll.name, []byte(data), coll.zkNodeVersion)
+	var oldState *CollectionState = nil
+	if coll.cachedState != nil {
+		oldState = coll.cachedState.collectionState
+	}
+	coll.updateReplicaVersionAndState(newState.collectionState, oldState)
 	coll.zkNodeVersion = version
 	coll.cachedState = newState
 }
 
 func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, oldState *CollectionState) {
-	if oldState == nil {
+	if oldState == nil || newState == nil {
 		return
 	}
 	for shradName, newShardState := range newState.Shards {

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -463,6 +463,8 @@ func (coll *collection) start() error {
 func (coll *collection) setData(data string, version int32) {
 	if data == "" {
 		coll.parent.logger.Printf("%s: no data", coll.name)
+	} else {
+		coll.parent.logger.Printf("Hitesh:setData data %s", data)
 	}
 	coll.mu.Lock()
 	defer coll.mu.Unlock()

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -143,7 +143,7 @@ func (c *SolrMonitor) GetCollectionState(name string) (*CollectionState, error) 
 func (c *SolrMonitor) doGetCollectionState(name string) (*CollectionState, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	coll:= c.collections[name]
+	coll := c.collections[name]
 
 	if coll == nil {
 		return nil, nil
@@ -178,7 +178,7 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 }
 
 func (c *SolrMonitor) updateCollectionState(path string, children []string) error {
-	c.logger.Printf("updateCollectionState: children %s", children )
+	c.logger.Printf("updateCollectionState: children %s", children)
 	coll := c.getCollFromPath(path)
 	if coll == nil || len(children) == 0 {
 		//looks like we have not got the collection event yet; it  should be safe to ignore it
@@ -249,7 +249,7 @@ func (c *SolrMonitor) shouldWatchChildren(path string) bool {
 		// watch coll/state.json childrens for replica status
 		if strings.HasPrefix(path, c.solrRoot+"/collections/") && strings.HasSuffix(path, "/state.json") {
 			coll := c.getCollFromPath(path)
-			if coll != nil  {
+			if coll != nil {
 				return coll.isPRSEnabled()
 			}
 		}
@@ -392,7 +392,7 @@ type collection struct {
 	parent        *SolrMonitor // if nil, this collection object was removed from the ClusterState
 
 	collectionState *CollectionState
-	isWatched   bool
+	isWatched       bool
 }
 
 func parseStateData(name string, data []byte, version int32) (*CollectionState, error) {
@@ -471,7 +471,7 @@ func (coll *collection) startMonitoringReplicaStatus() {
 	path := coll.parent.solrRoot + "/collections/" + coll.name + "/state.json"
 
 	// TODO: need to revisit coll.isWatched flag(if zk disconnects?). we need to create watch once only Scott?
-	if  !coll.isWatched && coll.isPRSEnabled() {
+	if !coll.isWatched && coll.isPRSEnabled() {
 		err := coll.parent.zkWatcher.MonitorChildren(path)
 		if err == nil {
 			coll.parent.logger.Printf("startMonitoringReplicaStatus: watching collection [%s] children for PRS", coll.name)
@@ -480,6 +480,6 @@ func (coll *collection) startMonitoringReplicaStatus() {
 	}
 }
 
-func (coll *collection)  isPRSEnabled() bool {
+func (coll *collection) isPRSEnabled() bool {
 	return coll.collectionState != nil && coll.collectionState.isPRSEnabled()
 }

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -415,6 +415,10 @@ type parsedCollectionState struct {
 	err             error            // if non-nil, the error generated parsing stateData
 }
 
+func (pcs *parsedCollectionState) String() string {
+	return fmt.Sprintf("parsedCollectionState{collectionState:%+v}", pcs.collectionState)
+}
+
 // Returns the current collection state data.
 func (coll *collection) GetData() (*CollectionState, error) {
 	cachedState := func() *parsedCollectionState {

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -491,7 +491,6 @@ func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, 
 			for replicaName, newReplicasState := range newShardState.Replicas {
 				oldReplicaState, replicaFound := oldShardState.Replicas[replicaName]
 				if replicaFound {
-					newReplicasState.Leader = oldReplicaState.Leader
 					newReplicasState.Version = oldReplicaState.Version
 				}
 			}

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -446,7 +446,7 @@ func (coll *collection) setData(data string, version int32) {
 }
 
 func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, oldState *CollectionState) {
-	if oldState == nil || newState == nil || newState.isPRSEnabled() {
+	if oldState == nil || newState == nil || !newState.isPRSEnabled() {
 		return
 	}
 	for shradName, newShardState := range newState.Shards {

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -18,8 +18,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -167,8 +167,8 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 	default:
 		return fmt.Errorf("solrmonitor: unknown childrenChanged: %s", path)
 		//collectionsPath + "/" + coll.name + "/state.json"
-		if !strings.HasPrefix(path, c.solrRoot + "/collections/") || !strings.HasSuffix(path, "/state.json") {
-			return fmt.Errorf( "solrmonitor: unknown childrenChanged: %s", path)
+		if !strings.HasPrefix(path, c.solrRoot+"/collections/") || !strings.HasSuffix(path, "/state.json") {
+			return fmt.Errorf("solrmonitor: unknown childrenChanged: %s", path)
 		}
 		return c.updateCollectionState(path, children)
 	}
@@ -187,7 +187,7 @@ func (c *SolrMonitor) updateCollectionState(path string, children []string) erro
 		d := strings.Split(r, ":")
 		newv, _ := strconv.ParseInt(d[1], 10, 32)
 
-		if oldrs, found:= rmap[d[0]]; found {
+		if oldrs, found := rmap[d[0]]; found {
 			oldv, _ := strconv.ParseInt(oldrs[1], 10, 32)
 			if oldv > newv {
 				continue
@@ -253,7 +253,7 @@ func (c *SolrMonitor) shouldWatchChildren(path string) bool {
 	case c.solrRoot + "/live_nodes":
 		return true
 	default:
-		if strings.HasPrefix(path, c.solrRoot + "/collections/") && strings.HasSuffix(path, "/state.json") {
+		if strings.HasPrefix(path, c.solrRoot+"/collections/") && strings.HasSuffix(path, "/state.json") {
 			return true
 		}
 		return false
@@ -478,7 +478,7 @@ func (coll *collection) setData(data string, version int32) {
 	coll.cachedState = newState
 }
 
-func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, oldState *CollectionState)  {
+func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, oldState *CollectionState) {
 	if oldState == nil {
 		return
 	}
@@ -486,7 +486,7 @@ func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, 
 		oldShardState, found := oldState.Shards[shradName]
 		if found {
 			for replicaName, newReplicasState := range newShardState.Replicas {
-				oldReplicaState, replicaFound :=	oldShardState.Replicas[replicaName]
+				oldReplicaState, replicaFound := oldShardState.Replicas[replicaName]
 				if replicaFound {
 					newReplicasState.Leader = oldReplicaState.Leader
 					newReplicasState.Version = oldReplicaState.Version

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -488,6 +488,8 @@ func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, 
 				oldReplicaState, replicaFound := oldShardState.Replicas[replicaName]
 				if replicaFound {
 					newReplicasState.Version = oldReplicaState.Version
+					newReplicasState.State = oldReplicaState.State
+					newReplicasState.Leader = oldReplicaState.Leader
 				}
 			}
 		}

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -146,6 +146,84 @@ func TestCollectionChanges(t *testing.T) {
 	shouldExist(t, sm2, "c1")
 }
 
+func TestPRSProtocol(t *testing.T) {
+	sm, testutil := setup(t)
+	defer testutil.teardown()
+
+	shouldNotExist(t, sm, "c1")
+
+	zkCli := testutil.conn
+	zkCli.Create(sm.solrRoot+"/collections", nil, 0, zk.WorldACL(zk.PermAll))
+	_, err := zkCli.Create(sm.solrRoot+"/collections/c1", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shouldNotExist(t, sm, "c1")
+
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shouldNotExist(t, sm, "c1")
+
+	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{\"perReplicaState\":\"true\",	 \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\"}}}}}}"), -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shouldExist(t, sm, "c1")
+
+	// 1. adding PRS for replica R1, version 1, state down
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:1:D", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prsShouldExist(t, sm, "c1", "shard_1", "R1", "down", "false", 1)
+
+	// 2. adding PRS for replica R1, version 1 -same, state active => should ignore as same version
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:1:R", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prsShouldExist(t, sm, "c1", "shard_1", "R1", "down", "false", 1)
+
+	// 3. adding PRS for replica R1, version 2, state active
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:2:A", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prsShouldExist(t, sm, "c1", "shard_1", "R1", "active", "false", 2)
+
+	// 4. adding PRS for replica R1, version 3, state active and leader
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:3:A:L", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prsShouldExist(t, sm, "c1", "shard_1", "R1", "active", "true", 3)
+
+	//5. split shard
+	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{\"perReplicaState\":\"true\",	 \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\"}}}, \"shard_1_0\":{\"replicas\":{\"R1_0\":{\"core\":\"core1\"}}}, \"shard_1_1\":{\"replicas\":{\"R1_1\":{\"core\":\"core1\"}}}}}}"), -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 6. replica R1_0 should exist
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1_0:1:A:L", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prsShouldExist(t, sm, "c1", "shard_1_0", "R1_0", "active", "true", 1)
+
+	// 7. replica R1_1 should exist
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1_1:1:A:L", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prsShouldExist(t, sm, "c1", "shard_1_1", "R1_1", "active", "true", 1)
+}
+
 func TestBadStateJson(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -133,7 +133,7 @@ func TestCollectionChanges(t *testing.T) {
 	shard, _ := collectionState.Shards["shard_1"]
 	rep, _ := shard.Replicas["R1"]
 
-	if rep.Leader != "true" {
+	if rep.Leader != "false" {
 		t.Fatalf("replica is not leader %+v", rep)
 	}
 
@@ -153,7 +153,7 @@ func TestCollectionChanges(t *testing.T) {
 	shouldExist(t, sm2, "c1")
 }
 
-func DTestPRSProtocol(t *testing.T) {
+func TestPRSProtocol(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()
 
@@ -231,7 +231,7 @@ func DTestPRSProtocol(t *testing.T) {
 	prsShouldExist(t, sm, "c1", "shard_1_1", "R1_1", "active", "true", 1)
 }
 
-func DTestBadStateJson(t *testing.T) {
+func TestBadStateJson(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()
 

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -231,7 +231,8 @@ func TestPRSProtocol(t *testing.T) {
 	prsShouldExist(t, sm, "c1", "shard_1_1", "R1_1", "active", "true", 1)
 }
 
-func TestBadStateJson(t *testing.T) {
+//that was meant for cachedState, which we removed
+func DisbaledTestBadStateJson(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()
 

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -123,12 +123,19 @@ func TestCollectionChanges(t *testing.T) {
 
 	shouldNotExist(t, sm, "c1")
 
-	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{}}"), -1)
+	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{ \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\", \"Base_url\":\"solr\", \"node_name\":\"8984_solr\", \"state\":\"active\", \"leader\":\"false\", \"type\": \"NRT\", \"force_set_state\":\"false\"}}}}}}"), -1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	shouldExist(t, sm, "c1")
+	collectionState, _ := sm.GetCollectionState("c1")
+	shard, _ := collectionState.Shards["shard_1"]
+	rep, _ := shard.Replicas["R1"]
+
+	if rep.Leader != "true" {
+		t.Fatalf("replica is not leader %+v", rep)
+	}
 
 	// Get a fresh new solr monitor and make sure it starts in the right state.
 	w2 := NewZkWatcherMan(testutil.logger)
@@ -146,7 +153,7 @@ func TestCollectionChanges(t *testing.T) {
 	shouldExist(t, sm2, "c1")
 }
 
-func TestPRSProtocol(t *testing.T) {
+func DTestPRSProtocol(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()
 
@@ -224,7 +231,7 @@ func TestPRSProtocol(t *testing.T) {
 	prsShouldExist(t, sm, "c1", "shard_1_1", "R1_1", "active", "true", 1)
 }
 
-func TestBadStateJson(t *testing.T) {
+func DTestBadStateJson(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()
 

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -231,7 +231,7 @@ func TestPRSProtocol(t *testing.T) {
 	prsShouldExist(t, sm, "c1", "shard_1_1", "R1_1", "active", "true", 1)
 }
 
-//that was meant for cachedState, which we removed
+//that was meant for cachedState, which we removed as now we need to deserialize the stream as need to know PRS state of collection
 func DisbaledTestBadStateJson(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()

--- a/solrmonitor/util_test.go
+++ b/solrmonitor/util_test.go
@@ -76,7 +76,7 @@ func prsShouldExist(t *testing.T, sm *SolrMonitor, name string, shard string, re
 				continue
 			}
 
-			if val.PerReplicaState == "false" {
+			if !val.isPRSEnabled() {
 				t.Errorf("expected collection %s to be PRS", name)
 				continue
 			}

--- a/solrmonitor/util_test.go
+++ b/solrmonitor/util_test.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	checkTimeout  = 3 * time.Second
-	checkInterval = 10 * time.Millisecond
+	checkInterval = 500 * time.Millisecond
 )
 
 func shouldBecomeEq(t *testing.T, expected int32, actualFunc func() int32) {
@@ -50,7 +50,59 @@ func shouldExist(t *testing.T, sm *SolrMonitor, name string) {
 		}
 		time.Sleep(checkInterval)
 	}
-	t.Errorf("expected %s to exist, but it does not", name)
+	t.Fatalf("expected %s to exist, but it does not", name)
+}
+
+func prsShouldExist(t *testing.T, sm *SolrMonitor, name string, shard string, replica string, rstate string, leader string, version int32) {
+	t.Helper()
+
+	for end := time.Now().Add(checkTimeout); time.Now().Before(end); {
+		time.Sleep(checkInterval)
+		collectionState, err := sm.GetCollectionState(name)
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+		if collectionState != nil {
+			// GetCurrentState should be consistent
+			state, err := sm.GetCurrentState()
+			if err != nil {
+				t.Fatal(err)
+				return
+			}
+			val, ok := state[name]
+			if val == nil || !ok {
+				t.Errorf("expected %s to exist in state map, but it does not", name)
+				continue
+			}
+
+			if val.PerReplicaState == "false" {
+				t.Errorf("expected collection %s to be PRS", name)
+				continue
+			}
+
+			s, sfound := val.Shards[shard]
+			if !sfound {
+				t.Errorf("expected collection %s shard %s to be exist", name, shard)
+				continue
+			}
+
+			r, rfound := s.Replicas[replica]
+			if !rfound {
+				t.Errorf("expected shard %s 's, replica %s to be exist", shard, replica)
+				continue
+			}
+
+			if r.State != rstate || r.Leader != leader || r.Version != version {
+				t.Errorf("expected replica [%v] should be state[%s], leader[%s] and version[%d] ", r, rstate, leader, version)
+				continue
+			}
+
+			return // success
+		}
+	}
+
+	t.Fatalf("expected collection %s 's replica updated", name)
 }
 
 func shouldNotExist(t *testing.T, sm *SolrMonitor, name string) {
@@ -79,7 +131,7 @@ func shouldNotExist(t *testing.T, sm *SolrMonitor, name string) {
 		}
 		time.Sleep(checkInterval)
 	}
-	t.Errorf("expected %s to not exist, but it does", name)
+	t.Fatalf("expected %s to not exist, but it does", name)
 }
 
 func shouldError(t *testing.T, sm *SolrMonitor, name string) {


### PR DESCRIPTION
1. Solr keeps state of replica by creating a zk node under coll/state.json/R1:1:A:L. It does if the "perReplicaState" attribute of the collection is set to "true".
2. Removed cached state as we need to read collection attribute "perReplicaState(PRS)".
3. when PRS is enabled, we watch the zk node coll/state.json
4. In OnChildren update callback, we update the state of the collectionState.
5. We accept replica state if the version is higher than the locally saved.
6. State.json keeps the all information about shards. It get updated when solr shard move or shard split happens. (Thus in this callback we update replica status from the locally saved replica status)
7. Added test for it.
8. TODO: I need to test all solr scenarios (old collection, enable PRS, split, move).
9. Also, I have changed the collectionState struct attribute to "*ShardState". And shardstate attribute to "*ReplicaState"
10. Design doc: https://docs.google.com/document/d/1xdxpzUNmTZbk0vTMZqfen9R3ArdHokLITdiISBxCFUg/edit#heading=h.3nl0qdwf9gmo