### PR TITLE
Hitesh solr event listener

### DIFF
--- a/solrcheck/problems_test.go
+++ b/solrcheck/problems_test.go
@@ -31,17 +31,17 @@ func TestFindClusterProblems(t *testing.T) {
 	zkState := fakeZk{}
 
 	for collName, coll := range data.ClusterState {
-		collState := &solrmonitor.CollectionState{Shards: map[string]solrmonitor.ShardState{}}
+		collState := &solrmonitor.CollectionState{Shards: map[string]*solrmonitor.ShardState{}}
 		clusterState[collName] = collState
 		for shardName, shard := range coll {
-			shardState := solrmonitor.ShardState{
+			shardState := &solrmonitor.ShardState{
 				State:    shard.State,
 				Range:    shard.HashRange,
-				Replicas: map[string]solrmonitor.ReplicaState{},
+				Replicas: map[string]*solrmonitor.ReplicaState{},
 			}
 			collState.Shards[shardName] = shardState
 			for replicaName, replica := range shard.Replicas {
-				replicaState := solrmonitor.ReplicaState{
+				replicaState := &solrmonitor.ReplicaState{
 					State:    replica.State,
 					Core:     replica.Core,
 					BaseUrl:  replica.BaseURL,

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -1,7 +1,24 @@
 package solrmonitor
 
 /**
-The client can register the SolrEventListener to listen to the solr cluster events from the zookeeper.
+	The client can register the SolrEventListener to listen to the solr cluster state events from the zookeeper.
+
+	On startup, the events are fired in this order:
+		1. SolrLiveNodesChanged fires for all the solr live nodes (node which keeps indexes). It keeps watch on zk node /solr/live_nodes 's children
+		2. SolrQueryNodesChanged fires for all the solr query nodes (node which coordinates the query execution). It keeps watch on zk node /solr/live_query_nodes 's children
+		3. SolrCollectionsChanged fires for all collections that exist. It keeps watch on zk node /solr/collections 's children.
+			3.1 SolrCollectionStateChanged fires for each collection; keeps watch on zk node /solr/collections/collname/state.json
+			3.2 SolrCollectionReplicaStatesChanged fires if Per replica state(PRS) is enable for collection.
+				If PRS enable then it keeps watch on zk node /solr/collections/collname/state.json 's children. Those children represents state of each replica of collection
+				(reference https://issues.apache.org/jira/browse/SOLR-15052, https://docs.google.com/document/d/1xdxpzUNmTZbk0vTMZqfen9R3ArdHokLITdiISBxCFUg/edit )
+
+	After initialization it delivers events for following condition
+		1. SolrLiveNodesChanged if solr live nodes changes
+		2. SolrQueryNodesChanged if solr query node changes
+		3. SolrCollectionsChanged if number of collections changes in solr cluster
+		4. SolrCollectionStateChanged if collection's number of shards changes, or replica moves, or replica splits.
+		5. SolrCollectionReplicaStatesChanged if collection's replica goes up/down, or becomes leader
+
  */
 type SolrEventListener interface {
 	// all the live nodes in the solr cluster

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -1,8 +1,18 @@
 package solrmonitor
 
+/**
+The client can register the SolrEventListener to listen to the solr cluster events from the zookeeper.
+ */
 type SolrEventListener interface {
+	// all the live nodes in the solr cluster
 	SolrLiveNodesChanged(livenodes []string)
+
+	// all the query aggregator nodes in ths solr cluster
 	SolrQueryNodesChanged(querynodes []string)
+
+	// all the collections in the solr cluster
 	SolrCollectionsChanged(collections []string)
+
+	// current collection state
 	SolrCollectionChanged(name string, collectionState *CollectionState)
 }

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -17,5 +17,5 @@ type SolrEventListener interface {
 	SolrCollectionStateChanged(name string, collectionState *CollectionState)
 
 	// collection replica state changed
-	SolrCollectionReplicaStatesChanged(name string, replicaStates *map[string]*PerReplicaState)
+	SolrCollectionReplicaStatesChanged(name string, replicaStates map[string]*PerReplicaState)
 }

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -1,0 +1,7 @@
+package solrmonitor
+
+type SolrEventListener interface {
+	SolrLiveNodesChanged(livenodes []string)
+	SolrCollectionsChanged(collections []string)
+	SolrCollectionChanged(name string, collectionState *CollectionState)
+}

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -13,6 +13,9 @@ type SolrEventListener interface {
 	// all the collections in the solr cluster
 	SolrCollectionsChanged(collections []string)
 
-	// current collection state
-	SolrCollectionChanged(name string, collectionState *CollectionState)
+	// current collection state change
+	SolrCollectionStateChanged(name string, collectionState *CollectionState)
+
+	// collection replica state changed
+	SolrCollectionReplicaStatesChanged(name string, replicaStates *map[string]*PerReplicaState)
 }

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -1,33 +1,33 @@
 package solrmonitor
 
 /**
-	The client can register the SolrEventListener to listen to the solr cluster state events from the zookeeper.
+The client can register the SolrEventListener to listen to the solr cluster state events from the zookeeper.
 
-	On startup, the events are fired in this order:
-		1. SolrLiveNodesChanged fires for all the solr live nodes (node which keeps indexes). It keeps watch on zk node /solr/live_nodes 's children
-		2. SolrQueryNodesChanged fires for all the solr query nodes (node which coordinates the query execution). It keeps watch on zk node /solr/live_query_nodes 's children
-		3. SolrCollectionsChanged fires for all collections that exist. It keeps watch on zk node /solr/collections 's children.
-			3.1 SolrCollectionStateChanged fires for each collection; keeps watch on zk node /solr/collections/collname/state.json
-			3.2 SolrCollectionReplicaStatesChanged fires if Per replica state(PRS) is enable for collection.
-				If PRS enable then it keeps watch on zk node /solr/collections/collname/state.json 's children. Those children represents state of each replica of collection
-				(reference https://issues.apache.org/jira/browse/SOLR-15052, https://docs.google.com/document/d/1xdxpzUNmTZbk0vTMZqfen9R3ArdHokLITdiISBxCFUg/edit )
+On startup, the events are fired in this order:
+	1. SolrLiveNodesChanged fires for all the solr live nodes (node which keeps indexes). It keeps watch on zk node /solr/live_nodes 's children
+	2. SolrQueryNodesChanged fires for all the solr query nodes (node which coordinates the query execution). It keeps watch on zk node /solr/live_query_nodes 's children
+	3. SolrCollectionsChanged fires for all collections that exist. It keeps watch on zk node /solr/collections 's children.
+		3.1 SolrCollectionStateChanged fires for each collection; keeps watch on zk node /solr/collections/collname/state.json
+		3.2 SolrCollectionReplicaStatesChanged fires if Per replica state(PRS) is enable for collection.
+			If PRS enable then it keeps watch on zk node /solr/collections/collname/state.json 's children. Those children represents state of each replica of collection
+			(reference https://issues.apache.org/jira/browse/SOLR-15052, https://docs.google.com/document/d/1xdxpzUNmTZbk0vTMZqfen9R3ArdHokLITdiISBxCFUg/edit )
 
-	After initialization it delivers events for following condition
-		1. SolrLiveNodesChanged if solr live nodes changes
-		2. SolrQueryNodesChanged if solr query node changes
-		3. SolrCollectionsChanged if number of collections changes in solr cluster
-		4. SolrCollectionStateChanged if collection's number of shards changes, or replica moves, or replica splits.
-		5. SolrCollectionReplicaStatesChanged if collection's replica goes up/down, or becomes leader
+After initialization it delivers events for following condition
+	1. SolrLiveNodesChanged if solr live nodes changes
+	2. SolrQueryNodesChanged if solr query node changes
+	3. SolrCollectionsChanged if number of collections changes in solr cluster
+	4. SolrCollectionStateChanged if collection's number of shards changes, or replica moves, or replica splits.
+	5. SolrCollectionReplicaStatesChanged if collection's replica goes up/down, or becomes leader
 
-	4. If collection get deleted - for non prs
-		4.1 SolrCollectionStateChanged fires for collection's state.json, which get updated for each shard/replica
-		4.2	SolrCollectionStateChanged fires with all collections name except deleted collection.
-	5. If collection get deleted - for prs
-		4.1 following events happen
-			4.1.1 SolrCollectionReplicaStatesChanged fires for all replicas/shards in collection
-			4.1.2 SolrCollectionStateChanged fires for collection's state.json, which get updated for each shard/replica
-		4.2	SolrCollectionStateChanged fires with all collections name except deleted collection.
- */
+4. If collection get deleted - for non PRS
+	4.1 SolrCollectionStateChanged fires for collection's state.json, which get updated for each shard/replica
+	4.2	SolrCollectionStateChanged fires with all collections name except deleted collection.
+5. If collection get deleted - for PRS
+	5.1 following events happen
+		4.1.1 SolrCollectionReplicaStatesChanged fires for all replicas/shards in collection
+		4.1.2 SolrCollectionStateChanged fires for collection's state.json, which get updated for each shard/replica
+	5.2	SolrCollectionStateChanged fires with all collections name except deleted collection.
+*/
 type SolrEventListener interface {
 	// all the live nodes in the solr cluster
 	SolrLiveNodesChanged(livenodes []string)

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -2,6 +2,7 @@ package solrmonitor
 
 type SolrEventListener interface {
 	SolrLiveNodesChanged(livenodes []string)
+	SolrQueryNodesChanged(querynodes []string)
 	SolrCollectionsChanged(collections []string)
 	SolrCollectionChanged(name string, collectionState *CollectionState)
 }

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -19,6 +19,14 @@ package solrmonitor
 		4. SolrCollectionStateChanged if collection's number of shards changes, or replica moves, or replica splits.
 		5. SolrCollectionReplicaStatesChanged if collection's replica goes up/down, or becomes leader
 
+	4. If collection get deleted - for non prs
+		4.1 SolrCollectionStateChanged fires for collection's state.json, which get updated for each shard/replica
+		4.2	SolrCollectionStateChanged fires with all collections name except deleted collection.
+	5. If collection get deleted - for prs
+		4.1 following events happen
+			4.1.1 SolrCollectionReplicaStatesChanged fires for all replicas/shards in collection
+			4.1.2 SolrCollectionStateChanged fires for collection's state.json, which get updated for each shard/replica
+		4.2	SolrCollectionStateChanged fires with all collections name except deleted collection.
  */
 type SolrEventListener interface {
 	// all the live nodes in the solr cluster

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -32,7 +32,7 @@ type CollectionState struct {
 }
 
 func (cs *CollectionState) String() string {
-	return fmt.Sprintf("CollectionState{Shards:%+v, PerReplicaState:%s}", cs.Shards, cs.PerReplicaState)
+	return fmt.Sprintf("CollectionState\n{Shards:%+v, PerReplicaState:%s}\n", cs.Shards, cs.PerReplicaState)
 }
 
 type Router struct {

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -14,6 +14,8 @@
 
 package solrmonitor
 
+import "fmt"
+
 type CollectionState struct {
 	Shards            map[string]*ShardState `json:"shards"`            // map from shard name to shard state
 	ReplicationFactor string                 `json:"replicationFactor"` // e.g. "1" (yes, these are strings, not numbers)
@@ -27,6 +29,10 @@ type CollectionState struct {
 	ConfigName      string `json:"configName,omitempty"`   // the name of the node in solr/configs (in ZK) that this collection uses
 	ZkNodeVersion   int32  `json:"znodeVersion,omitempty"` // the ZK node version this state snapshot represents
 	PerReplicaState string `json:"perReplicaState"`        // whether collection keeps state for each replica separately
+}
+
+func (cs *CollectionState) String() string {
+	return fmt.Sprintf("CollectionState{Shards:%+v, PerReplicaState:%s}", cs.Shards, cs.PerReplicaState)
 }
 
 type Router struct {

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -15,20 +15,31 @@
 package solrmonitor
 
 type CollectionState struct {
-	Shards            map[string]ShardState `json:"shards"`            // map from shard name to shard state
-	ReplicationFactor string                `json:"replicationFactor"` // e.g. "1" (yes, these are strings, not numbers)
-	Router            Router                `json:"router"`            // e.g. {"name":"compositeId"}
-	MaxShardsPerNode  string                `json:"maxShardsPerNode"`  // e.g. "1" (yes, these are strings, not numbers)
-	AutoAddReplicas   string                `json:"autoAddReplicas"`   // e.g. "false" (yes, these are strings, not bools)
+	Shards            map[string]*ShardState `json:"shards"`            // map from shard name to shard state
+	ReplicationFactor string                 `json:"replicationFactor"` // e.g. "1" (yes, these are strings, not numbers)
+	Router            Router                 `json:"router"`            // e.g. {"name":"compositeId"}
+	MaxShardsPerNode  string                 `json:"maxShardsPerNode"`  // e.g. "1" (yes, these are strings, not numbers)
+	AutoAddReplicas   string                 `json:"autoAddReplicas"`   // e.g. "false" (yes, these are strings, not bools)
 
 	// These fields are synthetic. They ARE present in COLLECTIONSTATUS response in
 	// solr collection API, but they are NOT in state.json docs in Zookeeper.
 
 	ConfigName      string `json:"configName,omitempty"`   // the name of the node in solr/configs (in ZK) that this collection uses
 	ZkNodeVersion   int32  `json:"znodeVersion,omitempty"` // the ZK node version this state snapshot represents
-	PerReplicaState bool   `json:"per_replica_state"`      // whether collection keeps state for each replica separately
+	PerReplicaState string `json:"perReplicaState"`        // whether collection keeps state for each replica separately
 }
 
 type Router struct {
 	Name string `json:"name"` // e.g. "compositeId"
+}
+
+type PerReplicaState struct {
+	// name of the replica
+	Name string `json:"name"`
+	// replica's state version
+	Version int32 `json:"version"`
+	// is replica active
+	State string `json:"state"`
+	// If "true", this replica is the shard leader
+	Leader string `json:"leader,omitempty"`
 }

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -53,3 +53,11 @@ type PerReplicaState struct {
 	// If "true", this replica is the shard leader
 	Leader string `json:"leader,omitempty"`
 }
+
+func (prs *PerReplicaState ) isActive() bool {
+	return prs.State == "active"
+}
+
+func (prs *PerReplicaState ) isLeader() bool {
+	return prs.Leader == "true"
+}

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -26,6 +26,7 @@ type CollectionState struct {
 
 	ConfigName    string `json:"configName,omitempty"`   // the name of the node in solr/configs (in ZK) that this collection uses
 	ZkNodeVersion int32  `json:"znodeVersion,omitempty"` // the ZK node version this state snapshot represents
+	PerReplicaState bool `json:"per_replica_state"` // whether collection keeps state for each replica separately
 }
 
 type Router struct {

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -24,9 +24,9 @@ type CollectionState struct {
 	// These fields are synthetic. They ARE present in COLLECTIONSTATUS response in
 	// solr collection API, but they are NOT in state.json docs in Zookeeper.
 
-	ConfigName    string `json:"configName,omitempty"`   // the name of the node in solr/configs (in ZK) that this collection uses
-	ZkNodeVersion int32  `json:"znodeVersion,omitempty"` // the ZK node version this state snapshot represents
-	PerReplicaState bool `json:"per_replica_state"` // whether collection keeps state for each replica separately
+	ConfigName      string `json:"configName,omitempty"`   // the name of the node in solr/configs (in ZK) that this collection uses
+	ZkNodeVersion   int32  `json:"znodeVersion,omitempty"` // the ZK node version this state snapshot represents
+	PerReplicaState bool   `json:"per_replica_state"`      // whether collection keeps state for each replica separately
 }
 
 type Router struct {

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -54,10 +54,10 @@ type PerReplicaState struct {
 	Leader string `json:"leader,omitempty"`
 }
 
-func (prs *PerReplicaState ) isActive() bool {
+func (prs *PerReplicaState ) IsActive() bool {
 	return prs.State == "active"
 }
 
-func (prs *PerReplicaState ) isLeader() bool {
+func (prs *PerReplicaState ) IsLeader() bool {
 	return prs.Leader == "true"
 }

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -54,10 +54,10 @@ type PerReplicaState struct {
 	Leader string `json:"leader,omitempty"`
 }
 
-func (prs *PerReplicaState ) IsActive() bool {
+func (prs *PerReplicaState) IsActive() bool {
 	return prs.State == "active"
 }
 
-func (prs *PerReplicaState ) IsLeader() bool {
+func (prs *PerReplicaState) IsLeader() bool {
 	return prs.Leader == "true"
 }

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -35,6 +35,10 @@ func (cs *CollectionState) String() string {
 	return fmt.Sprintf("CollectionState\n{Shards:%+v, PerReplicaState:%s}\n", cs.Shards, cs.PerReplicaState)
 }
 
+func (cs *CollectionState) isPRSEnabled() bool {
+	return cs.PerReplicaState == "true"
+}
+
 type Router struct {
 	Name string `json:"name"` // e.g. "compositeId"
 }

--- a/solrmonitor/main/solrmonitor/solrmonitor.go
+++ b/solrmonitor/main/solrmonitor/solrmonitor.go
@@ -79,7 +79,7 @@ func run(logger *log.Logger) error {
 		zkCli = flakyZk
 	}
 
-	solrMonitor, err := solrmonitor.NewSolrMonitorWithRoot(zkCli, zkWatcher, &solrmonitorLogger{logger: logger}, solrZkPath)
+	solrMonitor, err := solrmonitor.NewSolrMonitorWithRoot(zkCli, zkWatcher, &solrmonitorLogger{logger: logger}, solrZkPath, nil)
 	if err != nil {
 		return smutil.Cherrf(err, "Failed to create solrMonitor")
 	}

--- a/solrmonitor/mock.go
+++ b/solrmonitor/mock.go
@@ -4,9 +4,7 @@ func NewMockSolrMonitor(state ClusterState, liveNodes []string) *SolrMonitor {
 	collections := map[string]*collection{}
 	for k, v := range state {
 		collections[k] = &collection{
-			cachedState: &parsedCollectionState{
 				collectionState: v,
-			},
 		}
 	}
 	return &SolrMonitor{

--- a/solrmonitor/mock.go
+++ b/solrmonitor/mock.go
@@ -4,7 +4,7 @@ func NewMockSolrMonitor(state ClusterState, liveNodes []string) *SolrMonitor {
 	collections := map[string]*collection{}
 	for k, v := range state {
 		collections[k] = &collection{
-				collectionState: v,
+			collectionState: v,
 		}
 	}
 	return &SolrMonitor{

--- a/solrmonitor/replicastate.go
+++ b/solrmonitor/replicastate.go
@@ -26,7 +26,7 @@ type ReplicaState struct {
 }
 
 func (s *ReplicaState) String() string {
-	return fmt.Sprintf("ReplicaState{Core:%s, BaseUrl:%s, NodeName=%s, State=%s, Leader=%s, Version=%d}", s.Core, s.BaseUrl, s.NodeName, s.State, s.Leader, s.Version)
+	return fmt.Sprintf("\nReplicaState{Core:%s, BaseUrl:%s, NodeName=%s, State=%s, Leader=%s, Version=%d}\n", s.Core, s.BaseUrl, s.NodeName, s.State, s.Leader, s.Version)
 }
 
 func (r ReplicaState) IsActive() bool {

--- a/solrmonitor/replicastate.go
+++ b/solrmonitor/replicastate.go
@@ -20,6 +20,7 @@ type ReplicaState struct {
 	NodeName string `json:"node_name"` // e.g. "10.240.110.3:8983_solr"
 	State    string `json:"state"`     // e.g. "active", "inactive", "down", "recovering"
 	Leader   string `json:"leader"`    // e.g. "true" or "false" (yes, these are strings, not bools)
+	Version  int32  `json:"version"`   // e.g. "1" version of replica state
 }
 
 func (r ReplicaState) IsActive() bool {

--- a/solrmonitor/replicastate.go
+++ b/solrmonitor/replicastate.go
@@ -25,8 +25,8 @@ type ReplicaState struct {
 	Version  int32  `json:"version"`   // e.g. "1" version of replica state
 }
 
-func (s *ReplicaState) String() string {
-	return fmt.Sprintf("\nReplicaState{Core:%s, BaseUrl:%s, NodeName=%s, State=%s, Leader=%s, Version=%d}\n", s.Core, s.BaseUrl, s.NodeName, s.State, s.Leader, s.Version)
+func (r *ReplicaState) String() string {
+	return fmt.Sprintf("\nReplicaState{Core:%s, BaseUrl:%s, NodeName=%s, State=%s, Leader=%s, Version=%d}\n", r.Core, r.BaseUrl, r.NodeName, r.State, r.Leader, r.Version)
 }
 
 func (r ReplicaState) IsActive() bool {

--- a/solrmonitor/replicastate.go
+++ b/solrmonitor/replicastate.go
@@ -14,6 +14,8 @@
 
 package solrmonitor
 
+import "fmt"
+
 type ReplicaState struct {
 	Core     string `json:"core"`      // e.g. "delta_shard1_replica1"
 	BaseUrl  string `json:"base_url"`  // e.g. "http://10.240.110.3:8983/solr"
@@ -21,6 +23,10 @@ type ReplicaState struct {
 	State    string `json:"state"`     // e.g. "active", "inactive", "down", "recovering"
 	Leader   string `json:"leader"`    // e.g. "true" or "false" (yes, these are strings, not bools)
 	Version  int32  `json:"version"`   // e.g. "1" version of replica state
+}
+
+func (s *ReplicaState) String() string {
+	return fmt.Sprintf("ReplicaState{Core:%s, BaseUrl:%s, NodeName=%s, State=%s, Leader=%s, Version=%d}", s.Core, s.BaseUrl, s.NodeName, s.State, s.Leader, s.Version)
 }
 
 func (r ReplicaState) IsActive() bool {

--- a/solrmonitor/shardstate.go
+++ b/solrmonitor/shardstate.go
@@ -38,6 +38,10 @@ type bounds struct {
 	err error
 }
 
+func (ss *ShardState) String() string {
+	return fmt.Sprintf("ShardState{Range:%s, State:%s, Replicas=%+v, rangeBounds=%+v}", ss.Range, ss.State, ss.Replicas, ss.rangeBounds)
+}
+
 func (s ShardState) IsActive() bool {
 	return s.State == "active"
 }

--- a/solrmonitor/shardstate.go
+++ b/solrmonitor/shardstate.go
@@ -23,10 +23,10 @@ import (
 )
 
 type ShardState struct {
-	Parent   string                  `json:"parent"`
-	Range    string                  `json:"range"` // e.g. "80000000-b332ffff"
-	State    string                  `json:"state"` // e.g. "active", "inactive"
-	Replicas map[string]ReplicaState `json:"replicas,omitempty"`
+	Parent   string                   `json:"parent"`
+	Range    string                   `json:"range"` // e.g. "80000000-b332ffff"
+	State    string                   `json:"state"` // e.g. "active", "inactive"
+	Replicas map[string]*ReplicaState `json:"replicas,omitempty"`
 
 	rangeBounds      bounds
 	rangeInitialized bool

--- a/solrmonitor/shardstate.go
+++ b/solrmonitor/shardstate.go
@@ -38,8 +38,8 @@ type bounds struct {
 	err error
 }
 
-func (ss *ShardState) String() string {
-	return fmt.Sprintf("\nShardState{Range:%s, State:%s, Replicas=%+v, rangeBounds=%+v}\n", ss.Range, ss.State, ss.Replicas, ss.rangeBounds)
+func (s *ShardState) String() string {
+	return fmt.Sprintf("\nShardState{Range:%s, State:%s, Replicas=%+v, rangeBounds=%+v}\n", s.Range, s.State, s.Replicas, s.rangeBounds)
 }
 
 func (s ShardState) IsActive() bool {

--- a/solrmonitor/shardstate.go
+++ b/solrmonitor/shardstate.go
@@ -39,7 +39,7 @@ type bounds struct {
 }
 
 func (ss *ShardState) String() string {
-	return fmt.Sprintf("ShardState{Range:%s, State:%s, Replicas=%+v, rangeBounds=%+v}", ss.Range, ss.State, ss.Replicas, ss.rangeBounds)
+	return fmt.Sprintf("\nShardState{Range:%s, State:%s, Replicas=%+v, rangeBounds=%+v}\n", ss.Range, ss.State, ss.Replicas, ss.rangeBounds)
 }
 
 func (s ShardState) IsActive() bool {

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -175,7 +175,7 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 }
 
 func (c *SolrMonitor) updateCollectionState(path string, children []string) error {
-	c.logger.Printf("updateCollectionState: children %s", children )
+	c.logger.Printf("Hitesh:updateCollectionState: children %s", children )
 	coll := c.getCollFromPath(path)
 	if coll == nil || len(children) == 0 {
 		//looks like we have not got the collection event yet; it  should be safe to ignore it
@@ -217,7 +217,7 @@ func (c *SolrMonitor) updateCollectionState(path string, children []string) erro
 
 		rmap[prs.Name] = prs
 	}
-
+	c.logger.Printf("Hitesh:updateCollectionState PRS %+v", rmap)
 	coll.parent.mu.Lock()
 	defer coll.parent.mu.Unlock()
 	//update the collection state based on new PRS (per replica state)
@@ -232,6 +232,7 @@ func (c *SolrMonitor) updateCollectionState(path string, children []string) erro
 				}
 			}
 		}
+		c.logger.Printf("Hitesh:updateCollectionState collection added %+v", shard)
 	}
 
 	return nil
@@ -357,7 +358,7 @@ func (c *SolrMonitor) updateCollections(collections []string) error {
 			}
 		}
 	}()
-
+	c.logger.Printf("Hitesh:updateCollections collection added %s", added)
 	// Now start any new collections.
 	var errCount int32
 	var wg sync.WaitGroup
@@ -463,11 +464,13 @@ func (coll *collection) setData(data string, version int32) {
 	defer coll.mu.Unlock()
 	// we need to parse data here as we need to know PRS is enable for collection ot not; if enable then keep watch on coll/state.json children
 	newState := parseStateData(coll.name, []byte(data), coll.zkNodeVersion)
+	coll.parent.logger.Printf("Hitesh:setData collection newstate %+v", newState)
 	var oldState *CollectionState = nil
 	if coll.cachedState != nil {
 		oldState = coll.cachedState.collectionState
 	}
 	coll.updateReplicaVersionAndState(newState.collectionState, oldState)
+	coll.parent.logger.Printf("Hitesh:setData collection updated newstate %+v", newState)
 	coll.zkNodeVersion = version
 	coll.cachedState = newState
 }

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -320,9 +320,11 @@ func (c *SolrMonitor) dataChanged(path string, data string, version int32) error
 
 func (c *SolrMonitor) callSolrListener(coll *collection) {
 	if c.solrEventListener != nil {
+		c.logger.Printf("SolrCollectionChanged started %s ", coll.name)
 		c.mu.RLock()
 		defer c.mu.RUnlock()
 		c.solrEventListener.SolrCollectionChanged(coll.name, coll.collectionState)
+		c.logger.Printf("SolrCollectionChanged ended %s ", coll.name)
 	}
 }
 
@@ -379,6 +381,8 @@ func (c *SolrMonitor) start() error {
 func (c *SolrMonitor) updateCollections(collections []string) error {
 	var logAdded, logRemoved []string
 	logOldSize, logNewSize := len(c.collections), len(collections)
+
+	c.collectionsChanged(collections)
 
 	var added []*collection
 	func() {
@@ -440,14 +444,18 @@ func (c *SolrMonitor) updateCollections(collections []string) error {
 		return fmt.Errorf("%d/%d orgs failed to start", errCount, logNewSize)
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	return nil
+}
+
+func (c *SolrMonitor) collectionsChanged(collections []string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	if c.solrEventListener != nil {
+		c.logger.Printf("SolrCollectionsChanged started %s", collections)
 		c.solrEventListener.SolrCollectionsChanged(collections)
+		c.logger.Printf("SolrCollectionsChanged ended ")
 	}
-
-	return nil
 }
 
 func (c *SolrMonitor) updateLiveNodes(liveNodes []string) error {
@@ -456,7 +464,9 @@ func (c *SolrMonitor) updateLiveNodes(liveNodes []string) error {
 	defer c.mu.Unlock()
 	c.liveNodes = liveNodes
 	if c.solrEventListener != nil {
+		c.logger.Printf("SolrLiveNodesChanged started %s", liveNodes)
 		c.solrEventListener.SolrLiveNodesChanged(liveNodes)
+		c.logger.Printf("SolrLiveNodesChanged ended %s", liveNodes)
 	}
 	return nil
 }
@@ -467,7 +477,9 @@ func (c *SolrMonitor) updateLiveQueryNodes(queryNodes []string) error {
 	defer c.mu.Unlock()
 	c.queryNodes = queryNodes
 	if c.solrEventListener != nil {
+		c.logger.Printf("SolrQueryNodesChanged started %s", queryNodes)
 		c.solrEventListener.SolrQueryNodesChanged(c.queryNodes)
+		c.logger.Printf("SolrQueryNodesChanged started %s", queryNodes)
 	}
 	return nil
 }

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -161,6 +161,16 @@ func (c *SolrMonitor) doGetCollectionState(name string) (*CollectionState, error
 	return coll.collectionState, nil
 }
 
+func (c *SolrMonitor) GetQueryNodes() ([]string, error) {
+	if c.zkCli.State() != zk.StateHasSession {
+		return nil, errors.New("not currently connected to zk")
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return append([]string{}, c.queryNodes...), nil
+}
+
 func (c *SolrMonitor) GetLiveNodes() ([]string, error) {
 	if c.zkCli.State() != zk.StateHasSession {
 		return nil, errors.New("not currently connected to zk")

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -478,7 +478,7 @@ func (coll *collection) setData(data string, version int32) {
 }
 
 func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, oldState *CollectionState) {
-	if oldState == nil || newState == nil {
+	if oldState == nil || newState == nil || newState.PerReplicaState == "false" {
 		return
 	}
 	for shradName, newShardState := range newState.Shards {

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -145,6 +145,7 @@ func (c *SolrMonitor) doGetCollectionState(name string) (*CollectionState, error
 	if coll == nil {
 		return nil, nil
 	}
+
 	return coll.GetData()
 }
 
@@ -165,8 +166,7 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 	case c.solrRoot + "/live_nodes":
 		return c.updateLiveNodes(children)
 	default:
-		return fmt.Errorf("solrmonitor: unknown childrenChanged: %s", path)
-		//collectionsPath + "/" + coll.name + "/state.json"
+		//collectionsPath + "/" + coll.name + "/state.json": we want to state.json children
 		if !strings.HasPrefix(path, c.solrRoot+"/collections/") || !strings.HasSuffix(path, "/state.json") {
 			return fmt.Errorf("solrmonitor: unknown childrenChanged: %s", path)
 		}
@@ -175,84 +175,77 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 }
 
 func (c *SolrMonitor) updateCollectionState(path string, children []string) error {
+	c.logger.Printf("updateCollectionState: children %s", children )
 	coll := c.getCollFromPath(path)
 	if coll == nil || len(children) == 0 {
 		//looks like we have not got the collection event yet; it  should be safe to ignore it
 		return nil
 	}
 
-	rmap := map[string][]string{}
+	rmap := map[string]*PerReplicaState{}
 
-	for i, r := range children {
+	for _, r := range children {
 		d := strings.Split(r, ":")
-		newv, _ := strconv.ParseInt(d[1], 10, 32)
+		version, _ := strconv.ParseInt(d[1], 10, 32)
 
-		if oldrs, found := rmap[d[0]]; found {
-			oldv, _ := strconv.ParseInt(oldrs[1], 10, 32)
-			if oldv > newv {
+		prs := &PerReplicaState{
+			Name:    d[0],
+			Version: int32(version),
+		}
+
+		if d[2] == "A" {
+			prs.State = "active"
+		} else if d[2] == "D" {
+			prs.State = "down"
+		} else if d[2] == "R" {
+			prs.State = "recovering"
+		} else {
+			prs.State = "inactive"
+		}
+
+		prs.Leader = "false"
+		if len(d) == 4 {
+			prs.Leader = "true"
+		}
+
+		//keep ths latest prs
+		if currentPrs, found := rmap[prs.Name]; found {
+			if currentPrs.Version >= prs.Version {
 				continue
 			}
 		}
 
-		rmap[d[0]] = d
-		//its a bit hack to keep original data string as it is to pass downstream
-		d[0] = children[i]
+		rmap[prs.Name] = prs
 	}
 
 	coll.parent.mu.Lock()
 	defer coll.parent.mu.Unlock()
-
-	add := []string{}
-
+	//update the collection state based on new PRS (per replica state)
 	for _, shard := range coll.cachedState.collectionState.Shards {
-		replicaRemoved := []string{}
-		for lrn, lrs := range shard.Replicas {
-			if rs, found := rmap[lrn]; found {
-				v, _ := strconv.ParseInt(rs[1], 10, 32)
-				if v < int64(lrs.Version) {
-					panic(fmt.Sprintf("Collection {%s} replica %s status version %d should be greator than existing version %d ", coll.name, rs[1], lrs.Version, v))
-				}
+		for rname, rstate := range shard.Replicas {
+			if prs, found := rmap[rname]; found {
 				//if version is more than current then take that state
-				if int32(v) > lrs.Version {
-					lrs.Version = int32(v)
-
-					if rs[2] == "A" {
-						lrs.State = "active"
-					} else if rs[2] == "D" {
-						lrs.State = "down"
-					} else if rs[2] == "R" {
-						lrs.State = "recovering"
-					} else {
-						lrs.State = "inactive"
-					}
-
-					lrs.Leader = "false"
-					if len(rs) == 4 {
-						lrs.Leader = "true"
-					}
-
-					add = append(add, rs[0])
+				if prs.Version > rstate.Version {
+					rstate.Version = prs.Version
+					rstate.Leader = prs.Leader
+					rstate.State = prs.State
 				}
-			} else {
-				replicaRemoved = append(replicaRemoved, lrn)
-			}
-		}
-		if len(replicaRemoved) > 0 {
-			for _, replica := range replicaRemoved {
-				delete(shard.Replicas, replica)
 			}
 		}
 	}
+
 	return nil
 }
 
 func (c *SolrMonitor) shouldWatchChildren(path string) bool {
+	c.logger.Printf("shouldWatchChildren: path [%s]", path)
 	switch path {
 	case c.solrRoot + "/collections":
 		return true
 	case c.solrRoot + "/live_nodes":
 		return true
 	default:
+		// watch coll/state.json childrens for replica status
 		if strings.HasPrefix(path, c.solrRoot+"/collections/") && strings.HasSuffix(path, "/state.json") {
 			return true
 		}
@@ -268,8 +261,25 @@ func (c *SolrMonitor) dataChanged(path string, data string, version int32) error
 	coll := c.getCollFromPath(path)
 	if coll != nil {
 		coll.setData(data, version)
+		coll.startMonitoringReplicaStatus()
 	}
 	return nil
+}
+
+func (coll *collection) startMonitoringReplicaStatus() {
+	coll.mu.Lock()
+	defer coll.mu.Unlock()
+
+	path := coll.parent.solrRoot + "/collections/" + coll.name + "/state.json"
+
+	// TODO: need to revisit coll.isWatched flag(if zk disconnects?). we need to create watch once only Scott?
+	if coll.cachedState.collectionState != nil && !coll.isWatched && coll.cachedState.collectionState.PerReplicaState == "true" {
+		err := coll.parent.zkWatcher.MonitorChildren(path)
+		if err == nil {
+			coll.parent.logger.Printf("startMonitoringReplicaStatus: watching collection [%s] children for PRS", coll.name)
+			coll.isWatched = true
+		}
+	}
 }
 
 func (c *SolrMonitor) shouldWatchData(path string) bool {
@@ -392,11 +402,11 @@ func (c *SolrMonitor) updateLiveNodes(liveNodes []string) error {
 type collection struct {
 	mu            sync.RWMutex
 	name          string       // the name of the collection
-	stateData     string       // the current state.json data, or empty if no state.json node exists
 	zkNodeVersion int32        // the version of the state.json data, or -1 if no state.json node exists
 	parent        *SolrMonitor // if nil, this collection object was removed from the ClusterState
 
 	cachedState *parsedCollectionState // cached of the current parsed stateData if non-nil
+	isWatched   bool
 }
 
 type parsedCollectionState struct {
@@ -411,21 +421,6 @@ func (coll *collection) GetData() (*CollectionState, error) {
 		defer coll.mu.RUnlock()
 		return coll.cachedState
 	}()
-
-	if cachedState == nil {
-		cachedState = func() *parsedCollectionState {
-			coll.mu.Lock()
-			defer coll.mu.Unlock()
-
-			// Could have been initialized in between our first read and getting the write lock.
-			if coll.cachedState == nil {
-				coll.cachedState = parseStateData(coll.name, []byte(coll.stateData), coll.zkNodeVersion)
-			}
-
-			return coll.cachedState
-		}()
-	}
-
 	return cachedState.collectionState, cachedState.err
 }
 
@@ -457,11 +452,6 @@ func parseStateData(name string, data []byte, version int32) *parsedCollectionSt
 
 func (coll *collection) start() error {
 	path := coll.parent.solrRoot + "/collections/" + coll.name + "/state.json"
-	//look for childern as well
-	err := coll.parent.zkWatcher.MonitorData(path)
-	if err != nil {
-		return err
-	}
 	return coll.parent.zkWatcher.MonitorData(path)
 }
 
@@ -471,15 +461,19 @@ func (coll *collection) setData(data string, version int32) {
 	}
 	coll.mu.Lock()
 	defer coll.mu.Unlock()
-	newState := parseStateData(coll.name, []byte(coll.stateData), coll.zkNodeVersion)
-	coll.updateReplicaVersionAndState(newState.collectionState, coll.cachedState.collectionState)
-	coll.stateData = data
+	// we need to parse data here as we need to know PRS is enable for collection ot not; if enable then keep watch on coll/state.json children
+	newState := parseStateData(coll.name, []byte(data), coll.zkNodeVersion)
+	var oldState *CollectionState = nil
+	if coll.cachedState != nil {
+		oldState = coll.cachedState.collectionState
+	}
+	coll.updateReplicaVersionAndState(newState.collectionState, oldState)
 	coll.zkNodeVersion = version
 	coll.cachedState = newState
 }
 
 func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, oldState *CollectionState) {
-	if oldState == nil {
+	if oldState == nil || newState == nil {
 		return
 	}
 	for shradName, newShardState := range newState.Shards {

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	collectionsPath        = "/collections"
-	liveNodesPath          = "/live_nodes"
-	liveQueryNodesPath     = "/live_query_nodes"
+	collectionsPath    = "/collections"
+	liveNodesPath      = "/live_nodes"
+	liveQueryNodesPath = "/live_query_nodes"
 )
 
 // Keeps an in-memory copy of the current state of the Solr cluster; automatically updates on ZK changes.
@@ -320,11 +320,9 @@ func (c *SolrMonitor) dataChanged(path string, data string, version int32) error
 
 func (c *SolrMonitor) callSolrListener(coll *collection) {
 	if c.solrEventListener != nil {
-		c.logger.Printf("SolrCollectionChanged started %s ", coll.name)
 		c.mu.RLock()
 		defer c.mu.RUnlock()
 		c.solrEventListener.SolrCollectionChanged(coll.name, coll.collectionState)
-		c.logger.Printf("SolrCollectionChanged ended %s ", coll.name)
 	}
 }
 
@@ -452,9 +450,7 @@ func (c *SolrMonitor) collectionsChanged(collections []string) {
 	defer c.mu.RUnlock()
 
 	if c.solrEventListener != nil {
-		c.logger.Printf("SolrCollectionsChanged started %s", collections)
 		c.solrEventListener.SolrCollectionsChanged(collections)
-		c.logger.Printf("SolrCollectionsChanged ended ")
 	}
 }
 

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -200,7 +200,7 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 func (c *SolrMonitor) updateCollection(path string, children []string) error {
 	rs, err := c.updateCollectionState(path, children)
 
-	if err == nil && rs != nil && len(*rs) > 0 {
+	if err == nil && rs != nil && len(rs) > 0 {
 		coll := c.getCollFromPath(path)
 		if coll != nil {
 			c.mu.RLock()
@@ -215,7 +215,7 @@ func (c *SolrMonitor) updateCollection(path string, children []string) error {
 	return err
 }
 
-func (c *SolrMonitor) updateCollectionState(path string, children []string) (*map[string]*PerReplicaState, error) {
+func (c *SolrMonitor) updateCollectionState(path string, children []string) (map[string]*PerReplicaState, error) {
 	c.logger.Printf("updateCollectionState: children %s", children)
 	coll := c.getCollFromPath(path)
 	if coll == nil || len(children) == 0 {
@@ -287,7 +287,7 @@ func (c *SolrMonitor) updateCollectionState(path string, children []string) (*ma
 		}
 	}
 
-	return &rmap, nil
+	return rmap, nil
 }
 
 func (c *SolrMonitor) shouldWatchChildren(path string) bool {

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -463,6 +463,8 @@ func (coll *collection) start() error {
 func (coll *collection) setData(data string, version int32) {
 	if data == "" {
 		coll.parent.logger.Printf("%s: no data", coll.name)
+	} else {
+		coll.parent.logger.Printf("Hitesh:setData data %s", data)
 	}
 	coll.mu.Lock()
 	defer coll.mu.Unlock()

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -289,7 +289,7 @@ func (c *SolrMonitor) shouldWatchChildren(path string) bool {
 	switch path {
 	case c.solrRoot + collectionsPath:
 		return true
-	case c.solrRoot + liveQueryNodesPath:
+	case c.solrRoot + liveNodesPath:
 		return true
 	case c.solrRoot + liveQueryNodesPath:
 		return true
@@ -444,8 +444,6 @@ func (c *SolrMonitor) updateCollections(collections []string) error {
 	defer c.mu.Unlock()
 
 	if c.solrEventListener != nil {
-		c.mu.Lock()
-		defer c.mu.Unlock()
 		c.solrEventListener.SolrCollectionsChanged(collections)
 	}
 

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -143,7 +143,7 @@ func (c *SolrMonitor) GetCollectionState(name string) (*CollectionState, error) 
 func (c *SolrMonitor) doGetCollectionState(name string) (*CollectionState, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	coll:= c.collections[name]
+	coll := c.collections[name]
 
 	if coll == nil {
 		return nil, nil
@@ -178,7 +178,7 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 }
 
 func (c *SolrMonitor) updateCollectionState(path string, children []string) error {
-	c.logger.Printf("updateCollectionState: children %s", children )
+	c.logger.Printf("updateCollectionState: children %s", children)
 	coll := c.getCollFromPath(path)
 	if coll == nil || len(children) == 0 {
 		//looks like we have not got the collection event yet; it  should be safe to ignore it
@@ -249,7 +249,7 @@ func (c *SolrMonitor) shouldWatchChildren(path string) bool {
 		// watch coll/state.json childrens for replica status
 		if strings.HasPrefix(path, c.solrRoot+"/collections/") && strings.HasSuffix(path, "/state.json") {
 			coll := c.getCollFromPath(path)
-			if coll != nil  {
+			if coll != nil {
 				return coll.isPRSEnabled()
 			}
 		}
@@ -392,7 +392,7 @@ type collection struct {
 	parent        *SolrMonitor // if nil, this collection object was removed from the ClusterState
 
 	collectionState *CollectionState
-	isWatched   bool
+	isWatched       bool
 }
 
 func parseStateData(name string, data []byte, version int32) (*CollectionState, error) {
@@ -471,7 +471,7 @@ func (coll *collection) startMonitoringReplicaStatus() {
 	path := coll.parent.solrRoot + "/collections/" + coll.name + "/state.json"
 
 	// TODO: need to revisit coll.isWatched flag(if zk disconnects?). we need to create watch once only Scott?
-	if  !coll.isWatched && coll.isPRSEnabled() {
+	if !coll.isWatched && coll.isPRSEnabled() {
 		err := coll.parent.zkWatcher.MonitorChildren(path)
 		if err == nil {
 			coll.parent.logger.Printf("startMonitoringReplicaStatus: watching collection [%s] children for PRS", coll.name)
@@ -480,6 +480,6 @@ func (coll *collection) startMonitoringReplicaStatus() {
 	}
 }
 
-func (coll *collection)  isPRSEnabled() bool {
+func (coll *collection) isPRSEnabled() bool {
 	return coll.collectionState != nil && coll.collectionState.isPRSEnabled()
 }

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -368,13 +368,14 @@ func (c *SolrMonitor) start() error {
 	liveNodesPath := c.solrRoot + liveNodesPath
 	queryNodesPath := c.solrRoot + liveQueryNodesPath
 	c.zkWatcher.Start(c.zkCli, callbacks{c})
-	if err := c.zkWatcher.MonitorChildren(collectionsPath); err != nil {
-		return err
-	}
+
 	if err := c.zkWatcher.MonitorChildren(liveNodesPath); err != nil {
 		return err
 	}
 	if err := c.zkWatcher.MonitorChildren(queryNodesPath); err != nil {
+		return err
+	}
+	if err := c.zkWatcher.MonitorChildren(collectionsPath); err != nil {
 		return err
 	}
 	return nil

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -198,27 +198,32 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 	}
 }
 func (c *SolrMonitor) updateCollection(path string, children []string) error {
-	err := c.updateCollectionState(path, children)
+	rs, err := c.updateCollectionState(path, children)
 
-	if err == nil {
+	if err == nil && rs != nil && len(*rs) > 0 {
 		coll := c.getCollFromPath(path)
 		if coll != nil {
-			c.callSolrListener(coll)
+			c.mu.RLock()
+			defer c.mu.RUnlock()
+			if c.solrEventListener != nil {
+				collName := c.getCollNameFromPath(path)
+				c.solrEventListener.SolrCollectionReplicaStatesChanged(collName, rs)
+			}
 		}
 	}
 
 	return err
 }
 
-func (c *SolrMonitor) updateCollectionState(path string, children []string) error {
+func (c *SolrMonitor) updateCollectionState(path string, children []string) (*map[string]*PerReplicaState, error) {
 	c.logger.Printf("updateCollectionState: children %s", children)
 	coll := c.getCollFromPath(path)
 	if coll == nil || len(children) == 0 {
 		//looks like we have not got the collection event yet; it  should be safe to ignore it
-		return nil
+		return nil, nil
 	}
 
-	rmap := map[string]*PerReplicaState{}
+	rmap := make(map[string]*PerReplicaState)
 
 	for _, r := range children {
 		replicaParts := strings.Split(r, ":")
@@ -282,7 +287,7 @@ func (c *SolrMonitor) updateCollectionState(path string, children []string) erro
 		}
 	}
 
-	return nil
+	return &rmap, nil
 }
 
 func (c *SolrMonitor) shouldWatchChildren(path string) bool {
@@ -322,7 +327,7 @@ func (c *SolrMonitor) callSolrListener(coll *collection) {
 	if c.solrEventListener != nil {
 		c.mu.RLock()
 		defer c.mu.RUnlock()
-		c.solrEventListener.SolrCollectionChanged(coll.name, coll.collectionState)
+		c.solrEventListener.SolrCollectionStateChanged(coll.name, coll.collectionState)
 	}
 }
 

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -415,6 +415,10 @@ type parsedCollectionState struct {
 	err             error            // if non-nil, the error generated parsing stateData
 }
 
+func (pcs *parsedCollectionState) String() string {
+	return fmt.Sprintf("parsedCollectionState{collectionState:%+v}", pcs.collectionState)
+}
+
 // Returns the current collection state data.
 func (coll *collection) GetData() (*CollectionState, error) {
 	cachedState := func() *parsedCollectionState {

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -491,7 +491,6 @@ func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, 
 			for replicaName, newReplicasState := range newShardState.Replicas {
 				oldReplicaState, replicaFound := oldShardState.Replicas[replicaName]
 				if replicaFound {
-					newReplicasState.Leader = oldReplicaState.Leader
 					newReplicasState.Version = oldReplicaState.Version
 				}
 			}

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -446,7 +446,7 @@ func (coll *collection) setData(data string, version int32) {
 }
 
 func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, oldState *CollectionState) {
-	if oldState == nil || newState == nil || newState.isPRSEnabled() {
+	if oldState == nil || newState == nil || !newState.isPRSEnabled() {
 		return
 	}
 	for shradName, newShardState := range newState.Shards {

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -18,8 +18,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -167,8 +167,8 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 	default:
 		return fmt.Errorf("solrmonitor: unknown childrenChanged: %s", path)
 		//collectionsPath + "/" + coll.name + "/state.json"
-		if !strings.HasPrefix(path, c.solrRoot + "/collections/") || !strings.HasSuffix(path, "/state.json") {
-			return fmt.Errorf( "solrmonitor: unknown childrenChanged: %s", path)
+		if !strings.HasPrefix(path, c.solrRoot+"/collections/") || !strings.HasSuffix(path, "/state.json") {
+			return fmt.Errorf("solrmonitor: unknown childrenChanged: %s", path)
 		}
 		return c.updateCollectionState(path, children)
 	}
@@ -187,7 +187,7 @@ func (c *SolrMonitor) updateCollectionState(path string, children []string) erro
 		d := strings.Split(r, ":")
 		newv, _ := strconv.ParseInt(d[1], 10, 32)
 
-		if oldrs, found:= rmap[d[0]]; found {
+		if oldrs, found := rmap[d[0]]; found {
 			oldv, _ := strconv.ParseInt(oldrs[1], 10, 32)
 			if oldv > newv {
 				continue
@@ -253,7 +253,7 @@ func (c *SolrMonitor) shouldWatchChildren(path string) bool {
 	case c.solrRoot + "/live_nodes":
 		return true
 	default:
-		if strings.HasPrefix(path, c.solrRoot + "/collections/") && strings.HasSuffix(path, "/state.json") {
+		if strings.HasPrefix(path, c.solrRoot+"/collections/") && strings.HasSuffix(path, "/state.json") {
 			return true
 		}
 		return false
@@ -478,7 +478,7 @@ func (coll *collection) setData(data string, version int32) {
 	coll.cachedState = newState
 }
 
-func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, oldState *CollectionState)  {
+func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, oldState *CollectionState) {
 	if oldState == nil {
 		return
 	}
@@ -486,7 +486,7 @@ func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, 
 		oldShardState, found := oldState.Shards[shradName]
 		if found {
 			for replicaName, newReplicasState := range newShardState.Replicas {
-				oldReplicaState, replicaFound :=	oldShardState.Replicas[replicaName]
+				oldReplicaState, replicaFound := oldShardState.Replicas[replicaName]
 				if replicaFound {
 					newReplicasState.Leader = oldReplicaState.Leader
 					newReplicasState.Version = oldReplicaState.Version

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -488,6 +488,8 @@ func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, 
 				oldReplicaState, replicaFound := oldShardState.Replicas[replicaName]
 				if replicaFound {
 					newReplicasState.Version = oldReplicaState.Version
+					newReplicasState.State = oldReplicaState.State
+					newReplicasState.Leader = oldReplicaState.Leader
 				}
 			}
 		}

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -200,7 +200,7 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 func (c *SolrMonitor) updateCollection(path string, children []string) error {
 	err := c.updateCollectionState(path, children)
 
-	if err != nil {
+	if err == nil {
 		coll := c.getCollFromPath(path)
 		if coll != nil {
 			c.callSolrListener(coll)

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -146,6 +146,84 @@ func TestCollectionChanges(t *testing.T) {
 	shouldExist(t, sm2, "c1")
 }
 
+func TestPRSProtocol(t *testing.T) {
+	sm, testutil := setup(t)
+	defer testutil.teardown()
+
+	shouldNotExist(t, sm, "c1")
+
+	zkCli := testutil.conn
+	zkCli.Create(sm.solrRoot+"/collections", nil, 0, zk.WorldACL(zk.PermAll))
+	_, err := zkCli.Create(sm.solrRoot+"/collections/c1", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shouldNotExist(t, sm, "c1")
+
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shouldNotExist(t, sm, "c1")
+
+	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{\"perReplicaState\":\"true\",	 \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\"}}}}}}"), -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shouldExist(t, sm, "c1")
+
+	// 1. adding PRS for replica R1, version 1, state down
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:1:D", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prsShouldExist(t, sm, "c1", "shard_1", "R1", "down", "false", 1)
+
+	// 2. adding PRS for replica R1, version 1 -same, state active => should ignore as same version
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:1:R", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prsShouldExist(t, sm, "c1", "shard_1", "R1", "down", "false", 1)
+
+	// 3. adding PRS for replica R1, version 2, state active
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:2:A", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prsShouldExist(t, sm, "c1", "shard_1", "R1", "active", "false", 2)
+
+	// 4. adding PRS for replica R1, version 3, state active and leader
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:3:A:L", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prsShouldExist(t, sm, "c1", "shard_1", "R1", "active", "true", 3)
+
+	//5. split shard
+	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{\"perReplicaState\":\"true\",	 \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\"}}}, \"shard_1_0\":{\"replicas\":{\"R1_0\":{\"core\":\"core1\"}}}, \"shard_1_1\":{\"replicas\":{\"R1_1\":{\"core\":\"core1\"}}}}}}"), -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 6. replica R1_0 should exist
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1_0:1:A:L", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prsShouldExist(t, sm, "c1", "shard_1_0", "R1_0", "active", "true", 1)
+
+	// 7. replica R1_1 should exist
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1_1:1:A:L", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prsShouldExist(t, sm, "c1", "shard_1_1", "R1_1", "active", "true", 1)
+}
+
 func TestBadStateJson(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -29,12 +29,12 @@ import (
 )
 
 type testutil struct {
-	t      *testing.T
-	conn   *zk.Conn
-	root   string
-	sm     *SolrMonitor
-	logger *smtestutil.ZkTestLogger
-	solrEventListener	*SEListener
+	t                 *testing.T
+	conn              *zk.Conn
+	root              string
+	sm                *SolrMonitor
+	logger            *smtestutil.ZkTestLogger
+	solrEventListener *SEListener
 }
 
 func (tu *testutil) teardown() {
@@ -86,7 +86,7 @@ func setup(t *testing.T) (*SolrMonitor, *testutil) {
 		liveNodes:        0,
 		queryNodes:       0,
 		collections:      0,
-		collStateEvents: 0,
+		collStateEvents:  0,
 		collectionStates: make(map[string]*CollectionState),
 	}
 	sm, err := NewSolrMonitorWithRoot(conn, watcher, logger, root, l)
@@ -95,11 +95,11 @@ func setup(t *testing.T) (*SolrMonitor, *testutil) {
 		t.Fatal(err)
 	}
 	return sm, &testutil{
-		t:      t,
-		conn:   conn,
-		root:   root,
-		sm:     sm,
-		logger: logger,
+		t:                 t,
+		conn:              conn,
+		root:              root,
+		sm:                sm,
+		logger:            logger,
 		solrEventListener: l,
 	}
 }
@@ -161,7 +161,7 @@ func TestCollectionChanges(t *testing.T) {
 	}
 
 	if len(testutil.solrEventListener.collectionStates) != 1 || testutil.solrEventListener.collections != 1 {
-		t.Fatalf("Event listener didn't  not get event for collection  = %d, collectionstate = %d", testutil.solrEventListener.collections, len (testutil.solrEventListener.collectionStates))
+		t.Fatalf("Event listener didn't  not get event for collection  = %d, collectionstate = %d", testutil.solrEventListener.collections, len(testutil.solrEventListener.collectionStates))
 	}
 
 	if testutil.solrEventListener.liveNodes != 1 || testutil.solrEventListener.queryNodes != 1 {
@@ -198,7 +198,7 @@ func TestPRSProtocol(t *testing.T) {
 	}
 
 	shouldNotExist(t, sm, "c1")
-	checkCollectionStateCallback(1, testutil.solrEventListener.collStateEvents + testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(1, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
 
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json", nil, 0, zk.WorldACL(zk.PermAll))
 	if err != nil {
@@ -206,7 +206,7 @@ func TestPRSProtocol(t *testing.T) {
 	}
 
 	shouldNotExist(t, sm, "c1")
-	checkCollectionStateCallback(2, testutil.solrEventListener.collStateEvents + testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(2, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
 
 	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{\"perReplicaState\":\"true\",	 \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\"}}}}}}"), -1)
 	if err != nil {
@@ -214,7 +214,7 @@ func TestPRSProtocol(t *testing.T) {
 	}
 
 	shouldExist(t, sm, "c1")
-	checkCollectionStateCallback(3, testutil.solrEventListener.collStateEvents + testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(3, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
 
 	// 1. adding PRS for replica R1, version 1, state down
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:1:D", nil, 0, zk.WorldACL(zk.PermAll))
@@ -222,14 +222,14 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1", "R1", "down", "false", 1)
-	checkCollectionStateCallback(4, testutil.solrEventListener.collStateEvents + testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(4, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
 	// 2. adding PRS for replica R1, version 1 -same, state active => should ignore as same version
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:1:R", nil, 0, zk.WorldACL(zk.PermAll))
 	if err != nil {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1", "R1", "down", "false", 1)
-	checkCollectionStateCallback(5, testutil.solrEventListener.collStateEvents + testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(5, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
 
 	// 3. adding PRS for replica R1, version 2, state active
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:2:A", nil, 0, zk.WorldACL(zk.PermAll))
@@ -237,7 +237,7 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1", "R1", "active", "false", 2)
-	checkCollectionStateCallback(6, testutil.solrEventListener.collStateEvents + testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(6, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
 
 	// 4. adding PRS for replica R1, version 3, state active and leader
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:3:A:L", nil, 0, zk.WorldACL(zk.PermAll))
@@ -245,7 +245,7 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1", "R1", "active", "true", 3)
-	checkCollectionStateCallback(7, testutil.solrEventListener.collStateEvents + testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(7, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
 
 	//5. split shard
 	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{\"perReplicaState\":\"true\",	 \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\"}}}, \"shard_1_0\":{\"replicas\":{\"R1_0\":{\"core\":\"core1\"}}}, \"shard_1_1\":{\"replicas\":{\"R1_1\":{\"core\":\"core1\"}}}}}}"), -1)
@@ -253,7 +253,7 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	time.Sleep(5000 * time.Millisecond)
-	checkCollectionStateCallback(8, testutil.solrEventListener.collStateEvents + testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(8, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
 
 	// 6. replica R1_0 should exist
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1_0:1:A:L", nil, 0, zk.WorldACL(zk.PermAll))
@@ -261,7 +261,7 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1_0", "R1_0", "active", "true", 1)
-	checkCollectionStateCallback(9, testutil.solrEventListener.collStateEvents + testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(9, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
 
 	// 7. replica R1_1 should exist
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1_1:1:A:L", nil, 0, zk.WorldACL(zk.PermAll))
@@ -269,14 +269,14 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1_1", "R1_1", "active", "true", 1)
-	checkCollectionStateCallback(10, testutil.solrEventListener.collStateEvents + testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(10, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
 
 	if testutil.solrEventListener.collStateEvents != 4 || testutil.solrEventListener.collections != 1 {
 		t.Fatalf("Event listener didn't  not get event for collection  = %d, collectionstateEvents = %d", testutil.solrEventListener.collections, testutil.solrEventListener.collStateEvents)
 	}
 }
 
-func checkCollectionStateCallback(expected int, found int)  {
+func checkCollectionStateCallback(expected int, found int) {
 	if expected != found {
 		msg := fmt.Sprintf("listener event is %d, expected %d ", found, expected)
 		panic(msg)
@@ -310,12 +310,12 @@ func DisabledTestBadStateJson(t *testing.T) {
 }
 
 type SEListener struct {
-	liveNodes int
-	queryNodes int
-	collections int
-	collStateEvents int
+	liveNodes               int
+	queryNodes              int
+	collections             int
+	collStateEvents         int
 	collReplicaChangeEvents int
-	collectionStates map[string]*CollectionState
+	collectionStates        map[string]*CollectionState
 }
 
 func (l *SEListener) SolrLiveNodesChanged(livenodes []string) {
@@ -326,16 +326,15 @@ func (l *SEListener) SolrQueryNodesChanged(querynodes []string) {
 	l.queryNodes = len(querynodes)
 }
 
-func (l *SEListener)SolrCollectionsChanged(collections []string) {
+func (l *SEListener) SolrCollectionsChanged(collections []string) {
 	l.collections = len(collections)
 }
 
 func (l *SEListener) SolrCollectionStateChanged(name string, collectionState *CollectionState) {
-	l.collStateEvents++;
+	l.collStateEvents++
 	l.collectionStates[name] = collectionState
 }
 
 func (l *SEListener) SolrCollectionReplicaStatesChanged(name string, replicaStates map[string]*PerReplicaState) {
-	l.collReplicaChangeEvents++;
+	l.collReplicaChangeEvents++
 }
-

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -80,7 +80,7 @@ func setup(t *testing.T) (*SolrMonitor, *testutil) {
 		t.Fatal(err)
 	}
 
-	sm, err := NewSolrMonitorWithRoot(conn, watcher, logger, root)
+	sm, err := NewSolrMonitorWithRoot(conn, watcher, logger, root, nil)
 	if err != nil {
 		conn.Close()
 		t.Fatal(err)
@@ -144,7 +144,7 @@ func TestCollectionChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sm2, err := NewSolrMonitorWithRoot(conn2, w2, testutil.logger, testutil.root)
+	sm2, err := NewSolrMonitorWithRoot(conn2, w2, testutil.logger, testutil.root, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -133,7 +133,7 @@ func TestCollectionChanges(t *testing.T) {
 	shard, _ := collectionState.Shards["shard_1"]
 	rep, _ := shard.Replicas["R1"]
 
-	if rep.Leader != "true" {
+	if rep.Leader != "false" {
 		t.Fatalf("replica is not leader %+v", rep)
 	}
 
@@ -153,7 +153,7 @@ func TestCollectionChanges(t *testing.T) {
 	shouldExist(t, sm2, "c1")
 }
 
-func DTestPRSProtocol(t *testing.T) {
+func TestPRSProtocol(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()
 
@@ -231,7 +231,7 @@ func DTestPRSProtocol(t *testing.T) {
 	prsShouldExist(t, sm, "c1", "shard_1_1", "R1_1", "active", "true", 1)
 }
 
-func DTestBadStateJson(t *testing.T) {
+func TestBadStateJson(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()
 

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -335,7 +335,7 @@ func (l *SEListener) SolrCollectionStateChanged(name string, collectionState *Co
 	l.collectionStates[name] = collectionState
 }
 
-func (l *SEListener) SolrCollectionReplicaStatesChanged(name string, replicaStates *map[string]*PerReplicaState) {
+func (l *SEListener) SolrCollectionReplicaStatesChanged(name string, replicaStates map[string]*PerReplicaState) {
 	l.collReplicaChangeEvents++;
 }
 

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -231,7 +231,8 @@ func TestPRSProtocol(t *testing.T) {
 	prsShouldExist(t, sm, "c1", "shard_1_1", "R1_1", "active", "true", 1)
 }
 
-func TestBadStateJson(t *testing.T) {
+//that was meant for cachedState, which we removed
+func DisbaledTestBadStateJson(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()
 

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -123,12 +123,19 @@ func TestCollectionChanges(t *testing.T) {
 
 	shouldNotExist(t, sm, "c1")
 
-	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{}}"), -1)
+	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{ \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\", \"Base_url\":\"solr\", \"node_name\":\"8984_solr\", \"state\":\"active\", \"leader\":\"false\", \"type\": \"NRT\", \"force_set_state\":\"false\"}}}}}}"), -1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	shouldExist(t, sm, "c1")
+	collectionState, _ := sm.GetCollectionState("c1")
+	shard, _ := collectionState.Shards["shard_1"]
+	rep, _ := shard.Replicas["R1"]
+
+	if rep.Leader != "true" {
+		t.Fatalf("replica is not leader %+v", rep)
+	}
 
 	// Get a fresh new solr monitor and make sure it starts in the right state.
 	w2 := NewZkWatcherMan(testutil.logger)
@@ -146,7 +153,7 @@ func TestCollectionChanges(t *testing.T) {
 	shouldExist(t, sm2, "c1")
 }
 
-func TestPRSProtocol(t *testing.T) {
+func DTestPRSProtocol(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()
 
@@ -224,7 +231,7 @@ func TestPRSProtocol(t *testing.T) {
 	prsShouldExist(t, sm, "c1", "shard_1_1", "R1_1", "active", "true", 1)
 }
 
-func TestBadStateJson(t *testing.T) {
+func DTestBadStateJson(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()
 

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -231,7 +231,7 @@ func TestPRSProtocol(t *testing.T) {
 	prsShouldExist(t, sm, "c1", "shard_1_1", "R1_1", "active", "true", 1)
 }
 
-//that was meant for cachedState, which we removed
+//that was meant for cachedState, which we removed as now we need to deserialize the stream as need to know PRS state of collection
 func DisbaledTestBadStateJson(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -17,6 +17,7 @@
 package solrmonitor
 
 import (
+	"fmt"
 	"runtime"
 	"strings"
 	"testing"
@@ -85,6 +86,7 @@ func setup(t *testing.T) (*SolrMonitor, *testutil) {
 		liveNodes:        0,
 		queryNodes:       0,
 		collections:      0,
+		collStateEvents: 0,
 		collectionStates: make(map[string]*CollectionState),
 	}
 	sm, err := NewSolrMonitorWithRoot(conn, watcher, logger, root, l)
@@ -109,7 +111,7 @@ func disabledTestManual(t *testing.T) {
 	time.Sleep(10 * time.Minute)
 }
 
-func TestCollectionChanges(t *testing.T) {
+func DTestCollectionChanges(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()
 
@@ -196,6 +198,7 @@ func TestPRSProtocol(t *testing.T) {
 	}
 
 	shouldNotExist(t, sm, "c1")
+	checkCollectionStateCallback(1, testutil.solrEventListener.collStateEvents)
 
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json", nil, 0, zk.WorldACL(zk.PermAll))
 	if err != nil {
@@ -203,6 +206,7 @@ func TestPRSProtocol(t *testing.T) {
 	}
 
 	shouldNotExist(t, sm, "c1")
+	checkCollectionStateCallback(2, testutil.solrEventListener.collStateEvents)
 
 	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{\"perReplicaState\":\"true\",	 \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\"}}}}}}"), -1)
 	if err != nil {
@@ -210,6 +214,7 @@ func TestPRSProtocol(t *testing.T) {
 	}
 
 	shouldExist(t, sm, "c1")
+	checkCollectionStateCallback(4, testutil.solrEventListener.collStateEvents)
 
 	// 1. adding PRS for replica R1, version 1, state down
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:1:D", nil, 0, zk.WorldACL(zk.PermAll))
@@ -217,13 +222,14 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1", "R1", "down", "false", 1)
-
+	checkCollectionStateCallback(5, testutil.solrEventListener.collStateEvents)
 	// 2. adding PRS for replica R1, version 1 -same, state active => should ignore as same version
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:1:R", nil, 0, zk.WorldACL(zk.PermAll))
 	if err != nil {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1", "R1", "down", "false", 1)
+	checkCollectionStateCallback(6, testutil.solrEventListener.collStateEvents)
 
 	// 3. adding PRS for replica R1, version 2, state active
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:2:A", nil, 0, zk.WorldACL(zk.PermAll))
@@ -231,6 +237,7 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1", "R1", "active", "false", 2)
+	checkCollectionStateCallback(7, testutil.solrEventListener.collStateEvents)
 
 	// 4. adding PRS for replica R1, version 3, state active and leader
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:3:A:L", nil, 0, zk.WorldACL(zk.PermAll))
@@ -238,12 +245,15 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1", "R1", "active", "true", 3)
+	checkCollectionStateCallback(8, testutil.solrEventListener.collStateEvents)
 
 	//5. split shard
 	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{\"perReplicaState\":\"true\",	 \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\"}}}, \"shard_1_0\":{\"replicas\":{\"R1_0\":{\"core\":\"core1\"}}}, \"shard_1_1\":{\"replicas\":{\"R1_1\":{\"core\":\"core1\"}}}}}}"), -1)
 	if err != nil {
 		t.Fatal(err)
 	}
+	time.Sleep(5000 * time.Millisecond)
+	checkCollectionStateCallback(9, testutil.solrEventListener.collStateEvents)
 
 	// 6. replica R1_0 should exist
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1_0:1:A:L", nil, 0, zk.WorldACL(zk.PermAll))
@@ -251,6 +261,7 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1_0", "R1_0", "active", "true", 1)
+	checkCollectionStateCallback(10, testutil.solrEventListener.collStateEvents)
 
 	// 7. replica R1_1 should exist
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1_1:1:A:L", nil, 0, zk.WorldACL(zk.PermAll))
@@ -258,10 +269,22 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1_1", "R1_1", "active", "true", 1)
+	checkCollectionStateCallback(11, testutil.solrEventListener.collStateEvents)
+
+	if testutil.solrEventListener.collStateEvents != 11 || testutil.solrEventListener.collections != 1 {
+		t.Fatalf("Event listener didn't  not get event for collection  = %d, collectionstateEvents = %d", testutil.solrEventListener.collections, testutil.solrEventListener.collStateEvents)
+	}
+}
+
+func checkCollectionStateCallback(expected int, found int)  {
+	if expected != found {
+		msg := fmt.Sprintf("listener event is %d, expected %d ", found, expected)
+		panic(msg)
+	}
 }
 
 //that was meant for cachedState, which we removed as now we need to deserialize the stream as need to know PRS state of collection
-func DisbaledTestBadStateJson(t *testing.T) {
+func DisabledTestBadStateJson(t *testing.T) {
 	sm, testutil := setup(t)
 	defer testutil.teardown()
 
@@ -290,6 +313,7 @@ type SEListener struct {
 	liveNodes int
 	queryNodes int
 	collections int
+	collStateEvents int
 	collectionStates map[string]*CollectionState
 }
 
@@ -306,5 +330,6 @@ func (l *SEListener)SolrCollectionsChanged(collections []string) {
 }
 
 func (l *SEListener)SolrCollectionChanged(name string, collectionState *CollectionState) {
+	l.collStateEvents++;
 	l.collectionStates[name] = collectionState
 }

--- a/solrmonitor/util_test.go
+++ b/solrmonitor/util_test.go
@@ -76,7 +76,7 @@ func prsShouldExist(t *testing.T, sm *SolrMonitor, name string, shard string, re
 				continue
 			}
 
-			if val.PerReplicaState == "false" {
+			if !val.isPRSEnabled() {
 				t.Errorf("expected collection %s to be PRS", name)
 				continue
 			}

--- a/solrmonitor/util_test.go
+++ b/solrmonitor/util_test.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	checkTimeout  = 3 * time.Second
-	checkInterval = 10 * time.Millisecond
+	checkInterval = 500 * time.Millisecond
 )
 
 func shouldBecomeEq(t *testing.T, expected int32, actualFunc func() int32) {
@@ -50,7 +50,59 @@ func shouldExist(t *testing.T, sm *SolrMonitor, name string) {
 		}
 		time.Sleep(checkInterval)
 	}
-	t.Errorf("expected %s to exist, but it does not", name)
+	t.Fatalf("expected %s to exist, but it does not", name)
+}
+
+func prsShouldExist(t *testing.T, sm *SolrMonitor, name string, shard string, replica string, rstate string, leader string, version int32) {
+	t.Helper()
+
+	for end := time.Now().Add(checkTimeout); time.Now().Before(end); {
+		time.Sleep(checkInterval)
+		collectionState, err := sm.GetCollectionState(name)
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+		if collectionState != nil {
+			// GetCurrentState should be consistent
+			state, err := sm.GetCurrentState()
+			if err != nil {
+				t.Fatal(err)
+				return
+			}
+			val, ok := state[name]
+			if val == nil || !ok {
+				t.Errorf("expected %s to exist in state map, but it does not", name)
+				continue
+			}
+
+			if val.PerReplicaState == "false" {
+				t.Errorf("expected collection %s to be PRS", name)
+				continue
+			}
+
+			s, sfound := val.Shards[shard]
+			if !sfound {
+				t.Errorf("expected collection %s shard %s to be exist", name, shard)
+				continue
+			}
+
+			r, rfound := s.Replicas[replica]
+			if !rfound {
+				t.Errorf("expected shard %s 's, replica %s to be exist", shard, replica)
+				continue
+			}
+
+			if r.State != rstate || r.Leader != leader || r.Version != version {
+				t.Errorf("expected replica [%v] should be state[%s], leader[%s] and version[%d] ", r, rstate, leader, version)
+				continue
+			}
+
+			return // success
+		}
+	}
+
+	t.Fatalf("expected collection %s 's replica updated", name)
 }
 
 func shouldNotExist(t *testing.T, sm *SolrMonitor, name string) {
@@ -79,7 +131,7 @@ func shouldNotExist(t *testing.T, sm *SolrMonitor, name string) {
 		}
 		time.Sleep(checkInterval)
 	}
-	t.Errorf("expected %s to not exist, but it does", name)
+	t.Fatalf("expected %s to not exist, but it does", name)
 }
 
 func shouldError(t *testing.T, sm *SolrMonitor, name string) {


### PR DESCRIPTION
1. Added 'SolrEventListener' to solrmonitor. Client can implement 'SolrEventListener' interface to receive the callbacks for all solr cluster change.
2. Our solrmonitor will implement this. 
3. Also, solrman will also implement this interface for event driven architecture.
4. This PR also includes PRS stuff as we were testing all these testcases.
5. (I am happy to schedule session to go through all those changes )