### PR TITLE
multi-reasons for solrman disabled

### DIFF
--- a/solrman/smstorage/inmemory_storage.go
+++ b/solrman/smstorage/inmemory_storage.go
@@ -25,8 +25,7 @@ import (
 // Reference implementation for testing, don't use in production.
 type InMemoryStorage struct {
 	mu                             sync.RWMutex
-	disabled                       bool
-	disabledReason                 string
+	disabledReasons                map[string]string
 	splitsDisabled                 bool
 	tripsDisabled                  bool
 	movesDisabled                  bool
@@ -102,20 +101,35 @@ func (s *InMemoryStorage) GetStationaryOrgList() ([]string, error) {
 	return nil, nil
 }
 
-func (s *InMemoryStorage) IsDisabled() (bool, string) {
+func (s *InMemoryStorage) IsDisabled() (bool, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.disabled, s.disabledReason
+	return len(s.disabledReasons) > 0, nil
 }
 
-func (s *InMemoryStorage) SetDisabled(disabled bool, reason string) error {
+func (s *InMemoryStorage) GetDisabledReasons() (map[string]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.disabledReasons, nil
+
+}
+
+func (s *InMemoryStorage) AddDisabledReason(requestor string, reason string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.disabled = disabled
-	s.disabledReason = reason
+	s.disabledReasons[requestor] = reason
 	return nil
+}
+
+func (s *InMemoryStorage) RemoveDisabledReason(requestor string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.disabledReasons, requestor)
+  return nil
 }
 
 func (s *InMemoryStorage) GetDisabledTime() time.Time {

--- a/solrman/smstorage/inmemory_storage.go
+++ b/solrman/smstorage/inmemory_storage.go
@@ -129,7 +129,7 @@ func (s *InMemoryStorage) RemoveDisabledReason(requestor string) error {
 	defer s.mu.Unlock()
 
 	delete(s.disabledReasons, requestor)
-  return nil
+	return nil
 }
 
 func (s *InMemoryStorage) GetDisabledTime() time.Time {

--- a/solrman/smstorage/storage.go
+++ b/solrman/smstorage/storage.go
@@ -44,11 +44,11 @@ type SolrManStorage interface {
 	// Returns a list of solr orgs that should not be split or moved.
 	GetStationaryOrgList() ([]string, error)
 
-	IsDisabled() (bool, error)                        // if true, solrman is entirely disabled
-  GetDisabledReasons() (map[string]string, error)   // 
-	AddDisabledReason(string, string) error           // set solrman disabled with a required parameter of who is requesting it
-  RemoveDisabledReason(string) error                // remove the disabled status associated with the "requestor" param.
-	GetDisabledTime() time.Time                       // ms since the oldest disabled node was created
+	IsDisabled() (bool, error)                      // if true, solrman is entirely disabled
+	GetDisabledReasons() (map[string]string, error) //
+	AddDisabledReason(string, string) error         // set solrman disabled with a required parameter of who is requesting it
+	RemoveDisabledReason(string) error              // remove the disabled status associated with the "requestor" param.
+	GetDisabledTime() time.Time                     // ms since the oldest disabled node was created
 
 	IsSplitsDisabled() bool       // if true, don't do splits
 	SetSplitsDisabled(bool) error // disable splits

--- a/solrman/smstorage/storage.go
+++ b/solrman/smstorage/storage.go
@@ -44,9 +44,11 @@ type SolrManStorage interface {
 	// Returns a list of solr orgs that should not be split or moved.
 	GetStationaryOrgList() ([]string, error)
 
-	IsDisabled() (bool, string)     // if true, solrman is entirely disabled
-	SetDisabled(bool, string) error // disable solrman due to unrecoverable error completing an op
-	GetDisabledTime() time.Time     // ms since the disabled node was created
+	IsDisabled() (bool, error)                        // if true, solrman is entirely disabled
+  GetDisabledReasons() (map[string]string, error)   // 
+	AddDisabledReason(string, string) error           // set solrman disabled with a required parameter of who is requesting it
+  RemoveDisabledReason(string) error                // remove the disabled status associated with the "requestor" param.
+	GetDisabledTime() time.Time                       // ms since the oldest disabled node was created
 
 	IsSplitsDisabled() bool       // if true, don't do splits
 	SetSplitsDisabled(bool) error // disable splits

--- a/solrman/smstorage/zk_storage.go
+++ b/solrman/smstorage/zk_storage.go
@@ -17,7 +17,7 @@ package smstorage
 import (
 	"bytes"
 	"encoding/json"
-  "fmt"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -209,32 +209,32 @@ func (s *ZkStorage) GetStationaryOrgList() ([]string, error) {
 func (s *ZkStorage) IsDisabled() (bool, error) {
 	path := s.disabledPath()
 	children, _, err := s.conn.Children(path)
-  if err != nil {
-    s.logger.Errorf("could not check the children at %s in ZK: %s", path, err)
-    return true, err
+	if err != nil {
+		s.logger.Errorf("could not check the children at %s in ZK: %s", path, err)
+		return true, err
 
-  }
+	}
 	return len(children) > 0, nil
 }
 
 func (s *ZkStorage) GetDisabledReasons() (map[string]string, error) {
-  reasons := make(map[string]string)
+	reasons := make(map[string]string)
 	path := s.disabledPath()
 	children, _, err := s.conn.Children(path)
-  if err != nil {
-    s.logger.Errorf("could not check the children at %s in ZK: %s", path, err)
-    return reasons, err
-  }
+	if err != nil {
+		s.logger.Errorf("could not check the children at %s in ZK: %s", path, err)
+		return reasons, err
+	}
 
-  for _, child := range children {
-	  childPath := fmt.Sprintf("%s/%s", s.disabledPath(), child)
-    reason, _, err := s.conn.Get(childPath)
-    if err != nil {
-      return reasons, err
-    }
-    reasons[child] = string(reason)
-  }
-  return reasons, nil
+	for _, child := range children {
+		childPath := fmt.Sprintf("%s/%s", s.disabledPath(), child)
+		reason, _, err := s.conn.Get(childPath)
+		if err != nil {
+			return reasons, err
+		}
+		reasons[child] = string(reason)
+	}
+	return reasons, nil
 }
 
 // TODO(emily) check for existing reason
@@ -253,32 +253,32 @@ func (s *ZkStorage) RemoveDisabledReason(requestor string) error {
 	if err != nil && err != zk.ErrNoNode {
 		return smutil.Cherrf(err, "could not delete %s in ZK", path)
 	}
-  return nil
+	return nil
 }
 
 func (s *ZkStorage) GetDisabledTime() time.Time {
 	path := s.disabledPath()
 	children, _, err := s.conn.Children(path)
-  if err != nil {
-    s.logger.Errorf("could not check the children at %s in ZK: %s", path, err)
-    return time.Time{}
-  }
+	if err != nil {
+		s.logger.Errorf("could not check the children at %s in ZK: %s", path, err)
+		return time.Time{}
+	}
 
-  // Can use UnixMilli() once on go 1.17
-  oldest := time.Now().UnixNano() / int64(time.Millisecond)
-  for _, child := range children {
-	  path := fmt.Sprintf("%s/%s", s.disabledPath(), child)
-	  if exists, stat, err := s.conn.Exists(path); err != nil || !exists {
-		  if s.logger != nil && err != nil {
-			  s.logger.Errorf("could not check exists at %s in ZK: %s", path, err)
-		  }
-		  return time.Time{}
-	  } else {
-      if stat.Ctime < oldest {
-        oldest = stat.Ctime
-      }
-    }
-  }
+	// Can use UnixMilli() once on go 1.17
+	oldest := time.Now().UnixNano() / int64(time.Millisecond)
+	for _, child := range children {
+		path := fmt.Sprintf("%s/%s", s.disabledPath(), child)
+		if exists, stat, err := s.conn.Exists(path); err != nil || !exists {
+			if s.logger != nil && err != nil {
+				s.logger.Errorf("could not check exists at %s in ZK: %s", path, err)
+			}
+			return time.Time{}
+		} else {
+			if stat.Ctime < oldest {
+				oldest = stat.Ctime
+			}
+		}
+	}
 	// the Ctime is in ms since epoch, so convert before returning
 	return time.Unix(oldest/1000, 0)
 }

--- a/solrman/smstorage/zk_storage_test.go
+++ b/solrman/smstorage/zk_storage_test.go
@@ -156,19 +156,19 @@ func TestZkStorage_SetDisabled(t *testing.T) {
 		t.Errorf("%s should not exist", s.disabledPath())
 	}
 
-	s.AddDisabledReason("testor", "testSetDisabled")
+	s.AddDisabledReason("tester", "testSetDisabled")
 	if isDisabled, _ := s.IsDisabled(); !isDisabled {
 		t.Error("expected to be disabled")
 	}
-	if ok, _, _ := s.conn.Exists(s.disabledPath() + "/testor"); !ok {
+	if ok, _, _ := s.conn.Exists(s.disabledPath() + "/tester"); !ok {
 		t.Errorf("%s should exist", s.disabledPath())
 	}
 
-	s.RemoveDisabledReason("testor")
+	s.RemoveDisabledReason("tester")
 	if isDisabled, _ := s.IsDisabled(); isDisabled {
 		t.Error("expected to not be disabled")
 	}
-	if ok, _, _ := s.conn.Exists(s.disabledPath() + "/testor"); ok {
+	if ok, _, _ := s.conn.Exists(s.disabledPath() + "/tester"); ok {
 		t.Errorf("%s should not exist", s.disabledPath())
 	}
 }

--- a/solrman/smstorage/zk_storage_test.go
+++ b/solrman/smstorage/zk_storage_test.go
@@ -131,15 +131,16 @@ func TestZkStorage_IsDisabled(t *testing.T) {
 	s, testutil := setup(t)
 	defer testutil.teardown()
 
-	if isDisabled, reason := s.IsDisabled(); isDisabled {
+	if isDisabled, _ := s.IsDisabled(); isDisabled {
 		t.Error("expected to not be disabled")
 	}
 
-	testutil.createWithData(s.disabledPath(), "testDisabled")
+	testutil.createWithData(s.disabledPath() + "/test", "testDisabled")
 
-	if isDisabled, reason := s.IsDisabled(); !IsDisabled {
+	if isDisabled, _ := s.IsDisabled(); !IsDisabled{
 		t.Error("expected to be disabled")
-	} else if reason != "testDisabled" {
+	} else {
+    reason, _ := s.GetDisabledReasons(); reason[0] != "testDisabled" {
 		t.Errorf("expect reason is \"testDisabled\"; got %s", reason)
 	}
 
@@ -156,19 +157,19 @@ func TestZkStorage_SetDisabled(t *testing.T) {
 		t.Errorf("%s should not exist", s.disabledPath())
 	}
 
-	s.SetDisabled(true, "testSetDisabled")
-	if isDisabled, reason := s.IsDisabled(); !isDisabled {
+	s.AddDisabledReason("testor", "testSetDisabled")
+	if isDisabled, _ := s.IsDisabled(); !isDisabled {
 		t.Error("expected to be disabled")
 	}
-	if ok, _, _ := s.conn.Exists(s.disabledPath()); !ok {
+	if ok, _, _ := s.conn.Exists(s.disabledPath() + "/testor"); !ok {
 		t.Errorf("%s should exist", s.disabledPath())
 	}
 
-	s.SetDisabled(false)
-	if isDisabled, reason := s.IsDisabled(); isDisabled {
+	s.RemoveDisabledReason("testor")
+	if isDisabled, _:= s.IsDisabled(); isDisabled {
 		t.Error("expected to not be disabled")
 	}
-	if ok, _, _ := s.conn.Exists(s.disabledPath()); ok {
+	if ok, _, _ := s.conn.Exists(s.disabledPath() + "/testor"); ok {
 		t.Errorf("%s should not exist", s.disabledPath())
 	}
 }

--- a/solrman/smstorage/zk_storage_test.go
+++ b/solrman/smstorage/zk_storage_test.go
@@ -135,7 +135,7 @@ func TestZkStorage_IsDisabled(t *testing.T) {
 		t.Error("expected to not be disabled")
 	}
 
-	testutil.createWithData(s.disabledPath() + "/test", "testDisabled")
+	testutil.createWithData(s.disabledPath()+"/test", "testDisabled")
 
 	if isDisabled, _ := s.IsDisabled(); !IsDisabled {
 		t.Error("expected to be disabled")
@@ -165,7 +165,7 @@ func TestZkStorage_SetDisabled(t *testing.T) {
 	}
 
 	s.RemoveDisabledReason("testor")
-	if isDisabled, _:= s.IsDisabled(); isDisabled {
+	if isDisabled, _ := s.IsDisabled(); isDisabled {
 		t.Error("expected to not be disabled")
 	}
 	if ok, _, _ := s.conn.Exists(s.disabledPath() + "/testor"); ok {

--- a/solrman/smstorage/zk_storage_test.go
+++ b/solrman/smstorage/zk_storage_test.go
@@ -137,10 +137,9 @@ func TestZkStorage_IsDisabled(t *testing.T) {
 
 	testutil.createWithData(s.disabledPath() + "/test", "testDisabled")
 
-	if isDisabled, _ := s.IsDisabled(); !IsDisabled{
+	if isDisabled, _ := s.IsDisabled(); !IsDisabled {
 		t.Error("expected to be disabled")
-	} else {
-    reason, _ := s.GetDisabledReasons(); reason[0] != "testDisabled" {
+	} else if reasons, _ := s.GetDisabledReasons(); reasons[0] != "testDisabled" {
 		t.Errorf("expect reason is \"testDisabled\"; got %s", reason)
 	}
 


### PR DESCRIPTION
This allows multiple callers to set independent disabled states on solrman; only once all disabled states are removed is it considered reenabled. Requests to disable solrman are keyed by the requestor. This is part of the auto-enabling uberseer design, as having multiple places that can disable solrman would lead to incorrect reenabling or blocking other requests without stacking disables.