### PR TITLE
Added more granular read write lock

### DIFF
--- a/smutil/zkmutex_test.go
+++ b/smutil/zkmutex_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
 // +build integration
 
 package smutil_test

--- a/solrman/smstorage/zk_storage_test.go
+++ b/solrman/smstorage/zk_storage_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
 // +build integration
 
 package smstorage

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -318,7 +318,7 @@ func (c *SolrMonitor) dataChanged(path string, data string, version int32) error
 	if coll != nil {
 		coll.setData(data, version)
 		c.callSolrListener(coll)
-		if (coll.isPRSEnabled()) {
+		if coll.isPRSEnabled() {
 			coll.startMonitoringReplicaStatus()
 		}
 	}

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
 // +build integration
 
 package solrmonitor


### PR DESCRIPTION
1. Organized locks more granular.
2. Collection state updated in collection's write lock
3. Fetch collection state in read lock- (it reflects the state between two goroutines)
4. (All zk events are recursive. And golang locks are not reentrant. So making sure each path has one level of lock only)
5. (On start => we get all collections => we spawn goroutine for each collection =>  that sees prs enable on collection => that subscribe for collection's state.json children => that fetches all children(prs state)). Thus making sure nothing recursively locks on initialization.