### PR TITLE
more friction for moves in underloaded clusters

### DIFF
--- a/solrman/smmodel/model.go
+++ b/solrman/smmodel/model.go
@@ -213,15 +213,15 @@ func (m *Model) computeNextMove(immobileCores []bool) *Move {
 				}
 
 				// Don't bother moving this core if the target node would become bigger than the source node.
-				if target.Size + core.Size >= source.Size {
+				if target.Size+core.Size >= source.Size {
 					continue
 				}
 
-        // If the source is substantially under the maximum size, only move if the target node is substantially smaller than the source node.
-        // This is to avoid move thrashing in a cluster that is drastically below capacity while nodes are rapidly growing.
-        if source.Size < 10*m.MaxSizePerNode && target.Size + 5*core.Size >= source.Size {
-          continue
-        }
+				// If the source is substantially under the maximum size, only move if the target node is substantially smaller than the source node.
+				// This is to avoid move thrashing in a cluster that is drastically below capacity while nodes are rapidly growing.
+				if source.Size < 10*m.MaxSizePerNode && target.Size+5*core.Size >= source.Size {
+					continue
+				}
 
 				// Found a good candidate.
 				return &Move{

--- a/solrman/smmodel/model.go
+++ b/solrman/smmodel/model.go
@@ -213,9 +213,15 @@ func (m *Model) computeNextMove(immobileCores []bool) *Move {
 				}
 
 				// Don't bother moving this core if the target node would become bigger than the source node.
-				if target.Size+core.Size >= source.Size {
+				if target.Size + core.Size >= source.Size {
 					continue
 				}
+
+        // If the source is substantially under the maximum size, only move if the target node is substantially smaller than the source node.
+        // This is to avoid move thrashing in a cluster that is drastically below capacity while nodes are rapidly growing.
+        if source.Size < 10*m.MaxSizePerNode && target.Size + 5*core.Size >= source.Size {
+          continue
+        }
 
 				// Found a good candidate.
 				return &Move{


### PR DESCRIPTION
context: in spinning up a new cluster, there's orgs with fairly high traffic where they are thrashing the move algorithm. This is only a concern during the initial spinup of a cluster, but to that end, if a cluster is particularly underloaded (<10% of max data size), don't move for size reasons. Note: this will still allow moves for cluster balance reasons. 