### PR TITLE
Adding methods for getting split/move disabled times

### DIFF
--- a/solrman/smstorage/inmemory_storage.go
+++ b/solrman/smstorage/inmemory_storage.go
@@ -151,6 +151,10 @@ func (s *InMemoryStorage) SetSplitsDisabled(disabled bool) error {
 	return nil
 }
 
+func (s *InMemoryStorage) GetSplitsDisabledTime() time.Time {
+	return time.Time{}
+}
+
 func (s *InMemoryStorage) AreTripsDisabled() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -177,6 +181,10 @@ func (s *InMemoryStorage) SetMovesDisabled(disabled bool) error {
 
 	s.movesDisabled = disabled
 	return nil
+}
+
+func (s *InMemoryStorage) GetMovesDisabledTime() time.Time {
+	return time.Time{}
 }
 
 func (s *InMemoryStorage) IsStabbingEnabled() bool {

--- a/solrman/smstorage/storage.go
+++ b/solrman/smstorage/storage.go
@@ -48,18 +48,18 @@ type SolrManStorage interface {
 	GetDisabledReasons() (map[string]string, error) //
 	AddDisabledReason(string, string) error         // set solrman disabled with a required parameter of who is requesting it
 	RemoveDisabledReason(string) error              // remove the disabled status associated with the "requestor" param.
-	GetDisabledTime() time.Time                     // ms since the oldest disabled node was created
+	GetDisabledTime() time.Time                     // time since the oldest disabled node was created
 
 	IsSplitsDisabled() bool           // if true, don't do splits
 	SetSplitsDisabled(bool) error     // disable splits
-	GetSplitsDisabledTime() time.Time // ms since splits disabled
+	GetSplitsDisabledTime() time.Time // time since splits disabled
 
 	AreTripsDisabled() bool
 	SetTripsDisabled(bool) error
 
 	IsMovesDisabled() bool           // if true, don't do moves
 	SetMovesDisabled(bool) error     // disable moves
-	GetMovesDisabledTime() time.Time // ms since moves disabled
+	GetMovesDisabledTime() time.Time // time since moves disabled
 
 	IsStabbingEnabled() bool       // if true, Solrman will automatically restart problematic nodes
 	SetStabbingEnabled(bool) error // enable auutomatic node restarts

--- a/solrman/smstorage/storage.go
+++ b/solrman/smstorage/storage.go
@@ -50,14 +50,16 @@ type SolrManStorage interface {
 	RemoveDisabledReason(string) error              // remove the disabled status associated with the "requestor" param.
 	GetDisabledTime() time.Time                     // ms since the oldest disabled node was created
 
-	IsSplitsDisabled() bool       // if true, don't do splits
-	SetSplitsDisabled(bool) error // disable splits
+	IsSplitsDisabled() bool           // if true, don't do splits
+	SetSplitsDisabled(bool) error     // disable splits
+	GetSplitsDisabledTime() time.Time // ms since splits disabled
 
 	AreTripsDisabled() bool
 	SetTripsDisabled(bool) error
 
-	IsMovesDisabled() bool       // if true, don't do moves
-	SetMovesDisabled(bool) error // disable moves
+	IsMovesDisabled() bool           // if true, don't do moves
+	SetMovesDisabled(bool) error     // disable moves
+	GetMovesDisabledTime() time.Time // ms since moves disabled
 
 	IsStabbingEnabled() bool       // if true, Solrman will automatically restart problematic nodes
 	SetStabbingEnabled(bool) error // enable auutomatic node restarts

--- a/solrman/smstorage/zk_storage.go
+++ b/solrman/smstorage/zk_storage.go
@@ -320,7 +320,7 @@ func (s *ZkStorage) GetSplitsDisabledTime() time.Time {
 	}
 
 	if exists {
-		// the Ctime is in ms since epoch, so convert to seconds before returning
+		// the Ctime is in ms since epoch, so convert before returning
 		return time.Unix(stat.Ctime/1000, 0)
 	}
 
@@ -392,7 +392,7 @@ func (s *ZkStorage) GetMovesDisabledTime() time.Time {
 	}
 
 	if exists {
-		// the Ctime is in ms since epoch, so convert to seconds before returning
+		// the Ctime is in ms since epoch, so convert before returning
 		return time.Unix(stat.Ctime/1000, 0)
 	}
 

--- a/solrman/smstorage/zk_storage.go
+++ b/solrman/smstorage/zk_storage.go
@@ -311,6 +311,21 @@ func (s *ZkStorage) SetSplitsDisabled(disabled bool) error {
 	return nil
 }
 
+func (s *ZkStorage) GetSplitsDisabledTime() time.Time {
+	path := s.disableSplitsPath()
+	exists, stat, err := s.conn.Exists(path)
+	if err != nil {
+		s.logger.Errorf("could not check the splits disabled at %s in ZK: %s", path, err)
+		return time.Time{}
+	}
+
+	if exists {
+		return time.Unix(stat.Ctime/1000, 0)
+	}
+
+	return time.Time{}
+}
+
 func (s *ZkStorage) AreTripsDisabled() bool {
 	path := s.disableTripsPath()
 	exists, _, err := s.conn.Exists(path)
@@ -365,6 +380,21 @@ func (s *ZkStorage) SetMovesDisabled(disabled bool) error {
 		}
 	}
 	return nil
+}
+
+func (s *ZkStorage) GetMovesDisabledTime() time.Time {
+	path := s.disableMovesPath()
+	exists, stat, err := s.conn.Exists(path)
+	if err != nil {
+		s.logger.Errorf("could not check the moves disabled at %s in ZK: %s", path, err)
+		return time.Time{}
+	}
+
+	if exists {
+		return time.Unix(stat.Ctime/1000, 0)
+	}
+
+	return time.Time{}
 }
 
 func (s *ZkStorage) IsStabbingEnabled() bool {

--- a/solrman/smstorage/zk_storage.go
+++ b/solrman/smstorage/zk_storage.go
@@ -320,6 +320,7 @@ func (s *ZkStorage) GetSplitsDisabledTime() time.Time {
 	}
 
 	if exists {
+		// the Ctime is in ms since epoch, so convert to seconds before returning
 		return time.Unix(stat.Ctime/1000, 0)
 	}
 
@@ -391,6 +392,7 @@ func (s *ZkStorage) GetMovesDisabledTime() time.Time {
 	}
 
 	if exists {
+		// the Ctime is in ms since epoch, so convert to seconds before returning
 		return time.Unix(stat.Ctime/1000, 0)
 	}
 


### PR DESCRIPTION
These new methods will return the creation time for the split/move disabled path in Zookeeper. This will allow us to query to get the time since splits/moves were disabled to be able to use those for alerting in Solrman.