### PR TITLE
Improve solrman solrmonitor logging for prs

### DIFF
--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -270,7 +270,7 @@ func (c *SolrMonitor) updateCollectionState(path string, children []string) (map
 
 		rmap[prs.Name] = prs
 	}
-	c.logger.Printf("updateCollectionState on collection %s: updating prs state %s", coll, rmap)
+	c.logger.Printf("updateCollectionState on collection %s: updating prs state %s", coll.name, rmap)
 	coll.mu.Lock()
 	defer coll.mu.Unlock()
 	//update the collection state based on new PRS (per replica state)

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -270,7 +270,7 @@ func (c *SolrMonitor) updateCollectionState(path string, children []string) (map
 
 		rmap[prs.Name] = prs
 	}
-	c.logger.Printf("updateCollectionState: updating prs state %s", rmap)
+	c.logger.Printf("updateCollectionState on collection %s: updating prs state %s", coll, rmap)
 	coll.mu.Lock()
 	defer coll.mu.Unlock()
 	//update the collection state based on new PRS (per replica state)


### PR DESCRIPTION
## Description
While searching for logs on BQ, I usually use `jsonPayload.message LIKE '%<collenction name>%'`, however it would miss the PRS state update message as it does not contain the collection name

## Solution
Add the collection name as a part of the PRS update message 