### PR TITLE
Improved mock solrmonitor to support `SolrMonitor.GetLiveNodes`

### DIFF
--- a/solrmonitor/mock.go
+++ b/solrmonitor/mock.go
@@ -1,5 +1,7 @@
 package solrmonitor
 
+import "github.com/fullstorydev/zk"
+
 func NewMockSolrMonitor(state ClusterState, liveNodes []string) *SolrMonitor {
 	collections := map[string]*collection{}
 	for k, v := range state {
@@ -8,7 +10,38 @@ func NewMockSolrMonitor(state ClusterState, liveNodes []string) *SolrMonitor {
 		}
 	}
 	return &SolrMonitor{
+		zkCli:       newMockZkClient(),
 		collections: collections,
 		liveNodes:   liveNodes,
 	}
+}
+
+func newMockZkClient() ZkCli {
+	return mockZkClient{}
+}
+
+type mockZkClient struct {
+}
+
+func (m mockZkClient) ChildrenW(path string) ([]string, *zk.Stat, <-chan zk.Event, error) {
+	panic("Not implemented")
+}
+
+func (m mockZkClient) Get(path string) ([]byte, *zk.Stat, error) {
+	panic("Not implemented")
+}
+
+func (m mockZkClient) GetW(path string) ([]byte, *zk.Stat, <-chan zk.Event, error) {
+	panic("Not implemented")
+}
+
+func (m mockZkClient) ExistsW(path string) (bool, *zk.Stat, <-chan zk.Event, error) {
+	panic("Not implemented")
+}
+
+func (m mockZkClient) State() zk.State {
+	return zk.StateHasSession
+}
+
+func (m mockZkClient) Close() {
 }


### PR DESCRIPTION
## Description
The current `SolrMonitor.GetLiveNodes` call checks
```
if c.zkCli.State() != zk.StateHasSession {
		return nil, errors.New("not currently connected to zk")
	}
```
which panics for existing `NewMockSolrMonitor` as zkCli is `nil`


## Solution
Improve `NewMockSolrMonitor` to have a dummy zkCli which always returns `zk.StateHasSession` for `zkCli.State()`

## Remarks
This is necessary for writing unit test cases for solrman which calls `Cluster.GetLiveDataNode` which eventually delegates such call to `SolrMonitor`. 