### PR TITLE
Add replica field for `MoveShardRequest`

### DIFF
--- a/solrman/solrmanapi/request.go
+++ b/solrman/solrmanapi/request.go
@@ -23,7 +23,7 @@ type SolrmanStatusResponse struct {
 type MoveShardRequest struct {
 	Collection string
 	Shard      string
-	Replica    string
+	Replica    string // Name of the replica to be moved
 	SrcNode    string // Solr node name of the source node (e.g. "1.1.1.1:8983_solr"
 	DstNode    string // Solr node name of the destination node (e.g. "1.1.1.1:8983_solr"
 	Requestor  string // Username of who requested the operation ("solrman" if through automation)

--- a/solrman/solrmanapi/request.go
+++ b/solrman/solrmanapi/request.go
@@ -20,7 +20,7 @@ type SolrmanStatusResponse struct {
 	CompletedSolrOps  []OpRecord
 }
 
-type MoveReplicaRequest struct {
+type MoveShardRequest struct {
 	Collection string
 	Shard      string
 	Replica    string

--- a/solrman/solrmanapi/request.go
+++ b/solrman/solrmanapi/request.go
@@ -20,9 +20,10 @@ type SolrmanStatusResponse struct {
 	CompletedSolrOps  []OpRecord
 }
 
-type MoveShardRequest struct {
+type MoveReplicaRequest struct {
 	Collection string
 	Shard      string
+	Replica    string
 	SrcNode    string // Solr node name of the source node (e.g. "1.1.1.1:8983_solr"
 	DstNode    string // Solr node name of the destination node (e.g. "1.1.1.1:8983_solr"
 	Requestor  string // Username of who requested the operation ("solrman" if through automation)


### PR DESCRIPTION
## Description
The existing `MoveShardRequest` (a bit confusing in naming, it actually moves the replica of a shard) does not contain the actual name of the replica being moved. 

There are 2 issues:
1. If even momentarily a node has 2 replicas from the same shard (for example in the process of asynchronously swapping the PULL and NRT replicas between 2 nodes), the handler cannot tell which replica is it trying to move
2. Since the handler does not have such info, it would need to perform extra logic to locate the replica https://github.com/cowpaths/mn/blob/ea2e0be4b9e81f0a5f248ded4b53ca99e2ed32d2/projects/fullstory/go/src/fs/services/solrman/internal/solrmansvc/cluster.go#L573 , such might sometimes be unnecessary if the move analysis logic has already figured out which replica is the target


## Solution
Added `Replica` field to the `MoveShardRequest` struct

Tried to also renamed `MoveShardRequest` to `MoveReplicaRequest`, but it triggers too many changes, so perhaps doing that later on as a separate PR