### PR TITLE
Improve use of ZkCLI interface

### DIFF
--- a/smutil/zkmutex.go
+++ b/smutil/zkmutex.go
@@ -15,6 +15,7 @@
 package smutil
 
 import (
+	"github.com/fullstorydev/gosolr/solrmonitor"
 	"time"
 
 	"github.com/fullstorydev/zk"
@@ -28,14 +29,14 @@ import (
 // The caller must supply an implementation for `onLostMutex`.  If this ZK session is lost, or the underlying ZK
 // mutex node is deleted by an outside party, this implementation will call `onLostMutex`.  The caller must
 // release any resources guarded by the mutex.
-func AcquireAndMonitorZkMutex(logger Logger, conn *zk.Conn, path string, onLostMutex func()) (func(), error) {
+func AcquireAndMonitorZkMutex(logger Logger, conn solrmonitor.ZkCli, path string, onLostMutex func()) (func(), error) {
 	if err := acquireZkMutex(logger, conn, path); err != nil {
 		return func() {}, err
 	}
 	return monitorZkMutex(logger, conn, path, onLostMutex), nil
 }
 
-func acquireZkMutex(logger Logger, conn *zk.Conn, path string) error {
+func acquireZkMutex(logger Logger, conn solrmonitor.ZkCli, path string) error {
 	// Wait for up to a minute trying to acquire.
 	timeout := time.After(1 * time.Minute)
 	for {
@@ -82,7 +83,7 @@ func acquireZkMutex(logger Logger, conn *zk.Conn, path string) error {
 	}
 }
 
-func monitorZkMutex(logger Logger, conn *zk.Conn, path string, onLostMutex func()) func() {
+func monitorZkMutex(logger Logger, conn solrmonitor.ZkCli, path string, onLostMutex func()) func() {
 	shouldExit := make(chan struct{})
 	didExit := make(chan struct{})
 	go func() {

--- a/solrman/README.md
+++ b/solrman/README.md
@@ -1,5 +1,7 @@
 # solrman
 
+Test
+
 [![Solar Man by RazorsEdge701 on DeviantArt](solrman.jpg)](http://razorsedge701.deviantart.com/art/Solar-Man-52943088)
 
 Automatically balances a Solr cloud cluster.  Attempts to balance collections, total document count, and total disk size

--- a/solrman/README.md
+++ b/solrman/README.md
@@ -1,7 +1,5 @@
 # solrman
 
-Test
-
 [![Solar Man by RazorsEdge701 on DeviantArt](solrman.jpg)](http://razorsedge701.deviantart.com/art/Solar-Man-52943088)
 
 Automatically balances a Solr cloud cluster.  Attempts to balance collections, total document count, and total disk size

--- a/solrman/smstorage/zk_storage.go
+++ b/solrman/smstorage/zk_storage.go
@@ -24,10 +24,11 @@ import (
 
 	"github.com/fullstorydev/gosolr/smutil"
 	"github.com/fullstorydev/gosolr/solrman/solrmanapi"
+	"github.com/fullstorydev/gosolr/solrmonitor"
 	"github.com/fullstorydev/zk"
 )
 
-func NewZkStorage(conn *zk.Conn, root string, logger smutil.Logger) (*ZkStorage, error) {
+func NewZkStorage(conn *solrmonitor.ZkCli, root string, logger smutil.Logger) (*ZkStorage, error) {
 	ret := &ZkStorage{conn: conn, root: root, logger: logger}
 	if err := ret.init(); err != nil {
 		return nil, err
@@ -36,7 +37,7 @@ func NewZkStorage(conn *zk.Conn, root string, logger smutil.Logger) (*ZkStorage,
 }
 
 type ZkStorage struct {
-	conn   *zk.Conn
+	conn   *solrmonitor.ZkCli
 	root   string
 	logger smutil.Logger
 }

--- a/solrman/smstorage/zk_storage.go
+++ b/solrman/smstorage/zk_storage.go
@@ -28,7 +28,7 @@ import (
 	"github.com/fullstorydev/zk"
 )
 
-func NewZkStorage(conn *solrmonitor.ZkCli, root string, logger smutil.Logger) (*ZkStorage, error) {
+func NewZkStorage(conn solrmonitor.ZkCli, root string, logger smutil.Logger) (*ZkStorage, error) {
 	ret := &ZkStorage{conn: conn, root: root, logger: logger}
 	if err := ret.init(); err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func NewZkStorage(conn *solrmonitor.ZkCli, root string, logger smutil.Logger) (*
 }
 
 type ZkStorage struct {
-	conn   *solrmonitor.ZkCli
+	conn   solrmonitor.ZkCli
 	root   string
 	logger smutil.Logger
 }

--- a/solrmonitor/flaky_zookeeper.go
+++ b/solrmonitor/flaky_zookeeper.go
@@ -1,0 +1,115 @@
+package solrmonitor
+
+import (
+	"errors"
+	"github.com/fullstorydev/zk"
+	"math/rand"
+	"sync/atomic"
+)
+
+// TODO: make an integration test using this idea.
+
+// 60% of the time, it works every time
+const flakeChance = 0.60
+
+type SexPantherZkCli struct {
+	Delegate ZkCli
+	Rnd      *rand.Rand
+	Flaky    int32
+}
+
+var _ ZkCli = &SexPantherZkCli{}
+
+func (s *SexPantherZkCli) SetFlaky(flaky bool) {
+	if flaky {
+		atomic.StoreInt32(&s.Flaky, 1)
+	} else {
+		atomic.StoreInt32(&s.Flaky, 0)
+	}
+}
+
+func (s *SexPantherZkCli) isFlaky() bool {
+	return atomic.LoadInt32(&s.Flaky) != 0
+}
+
+func (s *SexPantherZkCli) Children(path string) ([]string, *zk.Stat, error) {
+	if s.isFlaky() && s.Rnd.Float32() > flakeChance {
+		return nil, nil, errors.New("flaky error")
+	}
+	return s.Delegate.Children(path)
+}
+
+func (s *SexPantherZkCli) Create(path string, data []byte, flags int32, acl []zk.ACL) (string, error) {
+	if s.isFlaky() && s.Rnd.Float32() > flakeChance {
+		return "", errors.New("flaky error")
+	}
+	return s.Delegate.Create(path, data, flags, acl)
+}
+
+func (s *SexPantherZkCli) Delete(path string, version int32) error {
+	if s.isFlaky() && s.Rnd.Float32() > flakeChance {
+		return errors.New("flaky error")
+	}
+	return s.Delegate.Delete(path, version)
+}
+
+func (s *SexPantherZkCli) Exists(path string) (bool, *zk.Stat, error) {
+	if s.isFlaky() && s.Rnd.Float32() > flakeChance {
+		return false, nil, errors.New("flaky error")
+	}
+	return s.Delegate.Exists(path)
+}
+
+func (s *SexPantherZkCli) SessionID() int64 {
+	return s.Delegate.SessionID()
+}
+
+func (s *SexPantherZkCli) Set(path string, contents []byte, version int32) (*zk.Stat, error) {
+	if s.isFlaky() && s.Rnd.Float32() > flakeChance {
+		return nil, errors.New("flaky error")
+	}
+	return s.Delegate.Set(path, contents, version)
+}
+
+func (s *SexPantherZkCli) Sync(path string) (string, error) {
+	if s.isFlaky() && s.Rnd.Float32() > flakeChance {
+		return "", errors.New("flaky error")
+	}
+	return s.Delegate.Sync(path)
+}
+
+func (s *SexPantherZkCli) ChildrenW(path string) ([]string, *zk.Stat, <-chan zk.Event, error) {
+	if s.isFlaky() && s.Rnd.Float32() > flakeChance {
+		return nil, nil, nil, errors.New("flaky error")
+	}
+	return s.Delegate.ChildrenW(path)
+}
+
+func (s *SexPantherZkCli) Get(path string) ([]byte, *zk.Stat, error) {
+	if s.isFlaky() && s.Rnd.Float32() > flakeChance {
+		return nil, nil, errors.New("flaky error")
+	}
+	return s.Delegate.Get(path)
+}
+
+func (s *SexPantherZkCli) GetW(path string) ([]byte, *zk.Stat, <-chan zk.Event, error) {
+	if s.isFlaky() && s.Rnd.Float32() > flakeChance {
+		return nil, nil, nil, errors.New("flaky error")
+	}
+	return s.Delegate.GetW(path)
+}
+
+func (s *SexPantherZkCli) ExistsW(path string) (bool, *zk.Stat, <-chan zk.Event, error) {
+	if s.isFlaky() && s.Rnd.Float32() > flakeChance {
+		return false, nil, nil, errors.New("flaky error")
+	}
+	return s.Delegate.ExistsW(path)
+}
+
+func (s *SexPantherZkCli) State() zk.State {
+	return s.Delegate.State()
+}
+
+func (s *SexPantherZkCli) Close() {
+	s.Delegate.Close()
+}

--- a/solrmonitor/main/solrmonitor/solrmonitor.go
+++ b/solrmonitor/main/solrmonitor/solrmonitor.go
@@ -202,6 +202,52 @@ func (s *sexPantherZkCli) isFlaky() bool {
 	return atomic.LoadInt32(&s.flaky) != 0
 }
 
+func (s *sexPantherZkCli) Children(path string) ([]string, *zk.Stat, error) {
+	if s.isFlaky() && s.rnd.Float32() > flakeChance {
+		return nil, nil, errors.New("flaky error")
+	}
+	return s.delegate.Children(path)
+}
+
+func (s *sexPantherZkCli) Create(path string, data []byte, flags int32, acl []zk.ACL) (string, error) {
+	if s.isFlaky() && s.rnd.Float32() > flakeChance {
+		return "", errors.New("flaky error")
+	}
+	return s.delegate.Create(path, data, flags, acl)
+}
+
+func (s *sexPantherZkCli) Delete(path string, version int32) error {
+	if s.isFlaky() && s.rnd.Float32() > flakeChance {
+		return errors.New("flaky error")
+	}
+	return s.delegate.Delete(path, version)
+}
+
+func (s *sexPantherZkCli) Exists(path string) (bool, *zk.Stat, error) {
+	if s.isFlaky() && s.rnd.Float32() > flakeChance {
+		return false, nil, errors.New("flaky error")
+	}
+	return s.delegate.Exists(path)
+}
+
+func (s *sexPantherZkCli) SessionID() int64 {
+	return s.delegate.SessionID()
+}
+
+func (s *sexPantherZkCli) Set(path string, contents []byte, version int32) (*zk.Stat, error) {
+	if s.isFlaky() && s.rnd.Float32() > flakeChance {
+		return nil, errors.New("flaky error")
+	}
+	return s.delegate.Set(path, contents, version)
+}
+
+func (s *sexPantherZkCli) Sync(path string) (string, error) {
+	if s.isFlaky() && s.rnd.Float32() > flakeChance {
+		return "", errors.New("flaky error")
+	}
+	return s.delegate.Sync(path)
+}
+
 func (s *sexPantherZkCli) ChildrenW(path string) ([]string, *zk.Stat, <-chan zk.Event, error) {
 	if s.isFlaky() && s.rnd.Float32() > flakeChance {
 		return nil, nil, nil, errors.New("flaky error")

--- a/solrmonitor/mock.go
+++ b/solrmonitor/mock.go
@@ -23,6 +23,34 @@ func newMockZkClient() ZkCli {
 type mockZkClient struct {
 }
 
+func (m mockZkClient) Children(path string) ([]string, *zk.Stat, error) {
+	panic("Not implemented")
+}
+
+func (m mockZkClient) Create(path string, data []byte, flags int32, acl []zk.ACL) (string, error) {
+	panic("Not implemented")
+}
+
+func (m mockZkClient) Delete(path string, version int32) error {
+	panic("Not implemented")
+}
+
+func (m mockZkClient) Exists(path string) (bool, *zk.Stat, error) {
+	panic("Not implemented")
+}
+
+func (m mockZkClient) SessionID() int64 {
+	panic("Not implemented")
+}
+
+func (m mockZkClient) Set(path string, contents []byte, version int32) (*zk.Stat, error) {
+	panic("Not implemented")
+}
+
+func (m mockZkClient) Sync(path string) (string, error) {
+	panic("Not implemented")
+}
+
 func (m mockZkClient) ChildrenW(path string) ([]string, *zk.Stat, <-chan zk.Event, error) {
 	panic("Not implemented")
 }

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -46,14 +46,21 @@ type SolrMonitor struct {
 	solrEventListener SolrEventListener      // to listen the solr cluster state
 }
 
-// Minimal interface solrmonitor needs (allows for mock ZK implementations).
+// Interface solrmonitor needs (allows for mock ZK implementations).
 type ZkCli interface {
+	Children(path string) ([]string, *zk.Stat, error)
 	ChildrenW(path string) ([]string, *zk.Stat, <-chan zk.Event, error)
+	Close()
+	Create(path string, data []byte, flags int32, acl []zk.ACL) (string, error)
+	Delete(path string, version int32) error
+	Exists(path string) (bool, *zk.Stat, error)
+	ExistsW(path string) (bool, *zk.Stat, <-chan zk.Event, error)
 	Get(path string) ([]byte, *zk.Stat, error)
 	GetW(path string) ([]byte, *zk.Stat, <-chan zk.Event, error)
-	ExistsW(path string) (bool, *zk.Stat, <-chan zk.Event, error)
+	SessionID() int64
+	Set(path string, contents []byte, version int32) (*zk.Stat, error)
 	State() zk.State
-	Close()
+	Sync(path string) (string, error)
 }
 
 // Create a new solrmonitor.  Solrmonitor takes ownership of the provided zkCli and zkWatcher-- they


### PR DESCRIPTION
Updates the ZkCLI interface to implement all methods such that it is compatible with zk.Conn and zookeeper.Client interfaces. This also modifies some direct uses of zk.Conn to instead use the ZkCLI interface.

There is one additional change here to move a flaky ZK CLI client used for testing to its own file since additional methods were required to be added for it.