### PR TITLE
Add GetOverseerNodes

### DIFF
--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -214,13 +214,18 @@ type zkRoleState struct {
 }
 
 func (c *SolrMonitor) rolesChanged(data string) error {
+	if len(data) == 0 {
+		return nil
+	}
 	var roles *zkRoleState
 	err := json.Unmarshal([]byte(data), &roles)
 	if err != nil {
+		c.logger.Printf("error when parsing JSON for roles: %s", err.Error())
 		return err
 	}
 	err = c.updateOverseerNodes(roles.Overseer)
 	if err != nil {
+		c.logger.Printf("error when updating overseer nodes: %s", err.Error())
 		return err
 	}
 	return nil

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -217,12 +217,14 @@ func (c *SolrMonitor) rolesChanged(data string) error {
 	if len(data) == 0 {
 		return nil
 	}
+
 	var roles *zkRoleState
 	err := json.Unmarshal([]byte(data), &roles)
 	if err != nil {
 		c.logger.Printf("error when parsing JSON for roles: %s", err.Error())
 		return err
 	}
+
 	err = c.updateOverseerNodes(roles.Overseer)
 	if err != nil {
 		c.logger.Printf("error when updating overseer nodes: %s", err.Error())
@@ -548,6 +550,7 @@ func (c *SolrMonitor) updateOverseerNodes(overseerNodes []string) error {
 	c.logger.Printf("%s (%d): %s", rolesPath, len(overseerNodes), overseerNodes)
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
 	c.overseerNodes = overseerNodes
 	return nil
 }

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -30,6 +30,7 @@ const (
 	collectionsPath    = "/collections"
 	liveNodesPath      = "/live_nodes"
 	liveQueryNodesPath = "/live_query_nodes"
+	rolesPath          = "/roles.json"
 )
 
 // Keeps an in-memory copy of the current state of the Solr cluster; automatically updates on ZK changes.
@@ -43,6 +44,7 @@ type SolrMonitor struct {
 	collections       map[string]*collection // map of all currently-known collections
 	liveNodes         []string               // current set of live_nodes
 	queryNodes        []string               // current set of live_query_nodes
+	overseerNodes     []string               // current set of overseer nodes (from roles.json)
 	solrEventListener SolrEventListener      // to listen the solr cluster state
 }
 
@@ -180,6 +182,16 @@ func (c *SolrMonitor) GetLiveNodes() ([]string, error) {
 	return append([]string{}, c.liveNodes...), nil
 }
 
+func (c *SolrMonitor) GetOverseerNodes() ([]string, error) {
+	if c.zkCli.State() != zk.StateHasSession {
+		return nil, errors.New("not currently connected to zk")
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return append([]string{}, c.overseerNodes...), nil
+}
+
 func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 	switch path {
 	case c.solrRoot + collectionsPath:
@@ -196,6 +208,24 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 		return c.updateCollection(path, children)
 	}
 }
+
+type zkRoleState struct {
+	Overseer []string "json:overseer"
+}
+
+func (c *SolrMonitor) rolesChanged(data string) error {
+	var roles *zkRoleState
+	err := json.Unmarshal([]byte(data), &roles)
+	if err != nil {
+		return err
+	}
+	err = c.updateOverseerNodes(roles.Overseer)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c *SolrMonitor) updateCollection(path string, children []string) error {
 	rs, err := c.updateCollectionState(path, children)
 
@@ -311,6 +341,10 @@ func (c *SolrMonitor) shouldWatchChildren(path string) bool {
 }
 
 func (c *SolrMonitor) dataChanged(path string, data string, version int32) error {
+	if strings.HasSuffix(path, rolesPath) {
+		return c.rolesChanged(data)
+	}
+
 	collectionsPrefix := c.solrRoot + "/collections/"
 	if !strings.HasPrefix(path, collectionsPrefix) {
 		// Expecting a collection in the /collections/ folder
@@ -386,6 +420,7 @@ func (c *SolrMonitor) start() error {
 	collectionsPath := c.solrRoot + collectionsPath
 	liveNodesPath := c.solrRoot + liveNodesPath
 	queryNodesPath := c.solrRoot + liveQueryNodesPath
+	rolesPath := c.solrRoot + rolesPath
 	c.zkWatcher.Start(c.zkCli, callbacks{c})
 
 	if err := c.zkWatcher.MonitorChildren(liveNodesPath); err != nil {
@@ -395,6 +430,9 @@ func (c *SolrMonitor) start() error {
 		return err
 	}
 	if err := c.zkWatcher.MonitorChildren(collectionsPath); err != nil {
+		return err
+	}
+	if err := c.zkWatcher.MonitorData(rolesPath); err != nil {
 		return err
 	}
 	return nil
@@ -498,6 +536,14 @@ func (c *SolrMonitor) updateLiveQueryNodes(queryNodes []string) error {
 	if c.solrEventListener != nil {
 		c.solrEventListener.SolrQueryNodesChanged(c.queryNodes)
 	}
+	return nil
+}
+
+func (c *SolrMonitor) updateOverseerNodes(overseerNodes []string) error {
+	c.logger.Printf("%s (%d): %s", rolesPath, len(overseerNodes), overseerNodes)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.overseerNodes = overseerNodes
 	return nil
 }
 

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -210,7 +210,7 @@ func (c *SolrMonitor) childrenChanged(path string, children []string) error {
 }
 
 type zkRoleState struct {
-	Overseer []string "json:overseer"
+	Overseer []string `json:"overseer"`
 }
 
 func (c *SolrMonitor) rolesChanged(data string) error {


### PR DESCRIPTION
This PR adds the GetOverseerNodes API to solrmonitor by parsing `roles.json`. This PR is necessary to enable using overseer nodes for admin operations in Solrman, and will be nice to have for any future code that requires knowing what the overseer nodes are. 