### PR TITLE
Removing cluster state file check from zk as it is removed from 9.0

### DIFF
--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -412,18 +412,6 @@ func (c *SolrMonitor) getCollNameFromPath(path string) string {
 func (c *SolrMonitor) start() error {
 	// Synchronously check the initial calls, then setup event listening.
 
-	// Ensure no state format v1 collections exist.
-	globalClusterStatePath := c.solrRoot + "/clusterstate.json"
-	globalClusterState, _, err := c.zkCli.Get(globalClusterStatePath)
-	if err != nil {
-		c.logger.Printf("%s: error fetching zk node: %s", globalClusterStatePath, err)
-		return err
-	}
-	if len(globalClusterState) > 2 {
-		err := fmt.Errorf("%s: solrmonitor does not support state format v1; zk node should contain only '{}'", globalClusterStatePath)
-		c.logger.Printf("please use Solr's MIGRATESTATEFORMAT collections command: %s", err)
-	}
-
 	collectionsPath := c.solrRoot + collectionsPath
 	liveNodesPath := c.solrRoot + liveNodesPath
 	queryNodesPath := c.solrRoot + liveQueryNodesPath

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -71,14 +71,8 @@ func setup(t *testing.T) (*SolrMonitor, *testutil) {
 		t.Fatal(err)
 	}
 
-	// Solrmonitor checks the "clusterstate.json" file in the root node it is given.
 	// So seed that file.
 	_, err = conn.Create(root, nil, 0, zk.WorldACL(zk.PermAll))
-	if err != nil && err != zk.ErrNodeExists {
-		conn.Close()
-		t.Fatal(err)
-	}
-	_, err = conn.Create(root+"/clusterstate.json", []byte("{}"), 0, zk.WorldACL(zk.PermAll))
 	if err != nil && err != zk.ErrNodeExists {
 		conn.Close()
 		t.Fatal(err)


### PR DESCRIPTION
I think its ok to remove now with solr 8.8. if we see any issue then I need to find some alternative for that