### PR TITLE
Make smutil a bit more flexible to handle both IP and hostname in node name

### DIFF
--- a/smutil/util.go
+++ b/smutil/util.go
@@ -43,8 +43,9 @@ func ParseNodeName(node string) (string, string, error) {
 	}
 }
 
-// GetHostname performs an address lookup on the ip portion of e.g. `127.0.0.1:8983_solr` and returns the first hostname returned.
-// If the lookup fails, then ip is returned.
+// GetHostname gets the hostname from a Solr node name (ie <host>:<port>_solr).
+// If the host part is an ip, then the hostname will be returned by address lookup;
+// otherwise it returns the host part assuming it is a hostname.
 func GetHostname(solrNode string) string {
 	host, _, err := ParseNodeName(solrNode)
 	if err != nil {

--- a/smutil/util.go
+++ b/smutil/util.go
@@ -23,7 +23,7 @@ import (
 	"github.com/fullstorydev/zk"
 )
 
-// ParseNodeName parses a solr node identifier into an IP/hostname, a port, and a suffix.
+// ParseNodeName parses a solr node identifier into an IP/hostname and a port.
 func ParseNodeName(node string) (string, string, error) {
 	suffixIndex := strings.LastIndex(node, "_")
 	if suffixIndex == -1 {

--- a/smutil/util.go
+++ b/smutil/util.go
@@ -24,6 +24,7 @@ import (
 )
 
 // ParseNodeName parses a solr node identifier into an IP/hostname and a port.
+// Node name is in format of <host>:<port>_solr which <host> could either be an IP or hostname
 func ParseNodeName(node string) (string, string, error) {
 	suffixIndex := strings.LastIndex(node, "_")
 	if suffixIndex == -1 {

--- a/smutil/util.go
+++ b/smutil/util.go
@@ -23,21 +23,23 @@ import (
 	"github.com/fullstorydev/zk"
 )
 
-// ParseNodeName parses a solr node identifier into an IP, a port, and a suffix.
+// ParseNodeName parses a solr node identifier into an IP/hostname, a port, and a suffix.
 func ParseNodeName(node string) (string, string, error) {
-	parts := strings.SplitN(node, "_", 2)
-	if len(parts) != 2 {
+	suffixIndex := strings.LastIndex(node, "_")
+	if suffixIndex == -1 {
 		return "", "", fmt.Errorf("malformed solr node identifier: no underscore present in %s", node)
 	}
 
-	if ip, port, err := net.SplitHostPort(parts[0]); err != nil {
-		return "", "", fmt.Errorf("%q is not a valid socket", parts[0])
+	hostAndPort := node[:suffixIndex]
+
+	if host, port, err := net.SplitHostPort(hostAndPort); err != nil {
+		return "", "", fmt.Errorf("%q is not a valid socket", hostAndPort)
 	} else {
 		_, err := strconv.ParseUint(port, 10, 16)
 		if err != nil {
 			return "", "", fmt.Errorf("%s is not a valid port", port)
 		}
-		return ip, port, nil
+		return host, port, nil
 	}
 }
 

--- a/smutil/util.go
+++ b/smutil/util.go
@@ -46,20 +46,25 @@ func ParseNodeName(node string) (string, string, error) {
 // GetHostname performs an address lookup on the ip portion of e.g. `127.0.0.1:8983_solr` and returns the first hostname returned.
 // If the lookup fails, then ip is returned.
 func GetHostname(solrNode string) string {
-	ip, _, err := ParseNodeName(solrNode)
+	host, _, err := ParseNodeName(solrNode)
 	if err != nil {
 		return ""
 	}
-	if names, err := net.LookupAddr(ip); err != nil {
-		return ip // fall back to just using the IP
-	} else {
-		// Just return the first part of the hostname
-		hostname := names[0]
-		i := strings.Index(hostname, ".")
-		if i > -1 {
-			hostname = hostname[:i]
+	if net.ParseIP(host) != nil { //then host is an IP address
+		ip := host
+		if names, err := net.LookupAddr(ip); err != nil {
+			return ip // fall back to just using the IP
+		} else {
+			hostname := names[0]
+			// Just return the first part of the hostname
+			i := strings.Index(hostname, ".")
+			if i > -1 {
+				hostname = hostname[:i]
+			}
+			return hostname
 		}
-		return hostname
+	} else { //then host is a hostname
+		return host
 	}
 }
 


### PR DESCRIPTION
## Description
Related to https://fullstory.atlassian.net/browse/SAI-4370 with attempts to use hostname in the node name instead of IPs.

Regardless of whether we go ahead with that change or not, it's still a good idea to improve our `ParseNodeName` and `GetHostName` methods to handle both IP and hostname in the `host` as in node name pattern `<host>:<port>_solr`

## Solution
For `ParseNodeName`,  I believe the existing implementation that breaks the node name down with underscore should really work with hostname too (since hostname should not have underscores).

But it's probably more future proof to just trim away the suffix, and fix the terminology used in the code anyway. 

For `GetHostName`, we can invoke `net.ParseIP(host)` to check if the host part is an IP, if so, use the old logic, otherwise return the non IP assuming that it's the hostname