### PR TITLE
Fixed configname for collections with solr9

### DIFF
--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -676,7 +676,9 @@ func (coll *collection) carryOverConfigName(newState *CollectionState) {
 		return
 	}
 	// Config name is managed separately, carry over as needed.
-	newState.ConfigName = coll.configName
+	if len(coll.configName) > 0 {
+		newState.ConfigName = coll.configName
+	}
 }
 
 func (coll *collection) startMonitoringReplicaStatus() {


### PR DESCRIPTION
https://fullstory.atlassian.net/browse/SAI-4423

In solr9, configname is part of state.json file
in solr8, configanme was data of collection name in zk