### PR TITLE
Updating to use max size per node that is set in the model

### DIFF
--- a/solrman/smmodel/model.go
+++ b/solrman/smmodel/model.go
@@ -23,8 +23,6 @@ type Model struct {
 	Nodes       []*Node       `json:"nodes"`
 	Collections []*Collection `json:"collections"`
 	Cores       []*Core
-
-	MaxSizePerNode int64 // maximum allowed size on a
 }
 
 func (m *Model) Add(core *Core) {
@@ -219,7 +217,7 @@ func (m *Model) computeNextMove(immobileCores []bool) *Move {
 
 				// If the source is substantially under the maximum size, only move if the target node is substantially smaller than the source node.
 				// This is to avoid move thrashing in a cluster that is drastically below capacity while nodes are rapidly growing.
-				if source.Size < 10*m.MaxSizePerNode && target.Size+5*core.Size >= source.Size {
+				if source.Size < 10*source.MaxSize && target.Size+5*core.Size >= source.Size {
 					continue
 				}
 
@@ -287,7 +285,7 @@ func (m *Model) computeNextMove(immobileCores []bool) *Move {
 				// no good choices
 				break
 			}
-			if m.MaxSizePerNode > 0 && target.Size >= m.MaxSizePerNode {
+			if target.MaxSize > 0 && target.Size >= target.MaxSize {
 				// too much data already on this node
 				continue
 			}

--- a/solrman/smmodel/node.go
+++ b/solrman/smmodel/node.go
@@ -8,7 +8,8 @@ type nodeId int
 type Node struct {
 	Name    string `json:"name"`
 	Address string `json:"address"`
-	Size    int64  `json:"size"` // in bytes
+	Size    int64  `json:"size"`    // in bytes
+	MaxSize int64  `json:"maxSize"` // in bytes
 
 	id nodeId
 

--- a/solrman/solrmanapi/cloudstatus.go
+++ b/solrman/solrmanapi/cloudstatus.go
@@ -24,6 +24,7 @@ type SolrNodeStatus struct {
 	NodeName string                     // the node's identifier within SolrCloud (e.g. "1.1.1.1:8983_solr")
 	Cores    map[string]*SolrCoreStatus // keys are core names
 	Zone     string                     // cloud zone where host exists
+	DiskSize float64
 }
 
 type SolrCoreStatus struct {


### PR DESCRIPTION
This allows for dynamically determining max node sizes instead of using hard coded values and potentially having nodes with different disk sizes.