### PR TITLE
Changes to use persistent recursive watch for PRS enabled collections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/fullstorydev/gosolr
 go 1.13
 
 require github.com/fullstorydev/zk v1.0.3-0.20200828191825-edfcb5d63fdd
+
+replace github.com/fullstorydev/zk => github.com/patsonluk/zk v1.0.3-0.20230609180938-ecd7812130b6

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 require github.com/fullstorydev/zk v1.0.3-0.20200828191825-edfcb5d63fdd
 
-replace github.com/fullstorydev/zk => github.com/patsonluk/zk v1.0.3-0.20230615223655-b658df33d417
+replace github.com/fullstorydev/zk => github.com/patsonluk/zk v1.0.3-0.20230609180938-ecd7812130b6

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 require github.com/fullstorydev/zk v1.0.3-0.20200828191825-edfcb5d63fdd
 
-replace github.com/fullstorydev/zk => github.com/patsonluk/zk v1.0.3-0.20230609180938-ecd7812130b6
+replace github.com/fullstorydev/zk => github.com/patsonluk/zk v1.0.3-0.20230615223655-b658df33d417

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/patsonluk/zk v1.0.3-0.20230615223655-b658df33d417 h1:rhmVyijPfnbJ4deZaEpYS737VLO+H6Y6nTWLHMeqvVI=
-github.com/patsonluk/zk v1.0.3-0.20230615223655-b658df33d417/go.mod h1:ssbnU3H1lBdE6eTeQ4pyY53X+kHUNqwongLRP8AYygo=
+github.com/patsonluk/zk v1.0.3-0.20230609180938-ecd7812130b6 h1:WyVmwrZEMo7UEcd1WoQvefQIdPIt31qrI7QUfUM1dZc=
+github.com/patsonluk/zk v1.0.3-0.20230609180938-ecd7812130b6/go.mod h1:ssbnU3H1lBdE6eTeQ4pyY53X+kHUNqwongLRP8AYygo=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/patsonluk/zk v1.0.3-0.20230609180938-ecd7812130b6 h1:WyVmwrZEMo7UEcd1WoQvefQIdPIt31qrI7QUfUM1dZc=
-github.com/patsonluk/zk v1.0.3-0.20230609180938-ecd7812130b6/go.mod h1:ssbnU3H1lBdE6eTeQ4pyY53X+kHUNqwongLRP8AYygo=
+github.com/patsonluk/zk v1.0.3-0.20230615223655-b658df33d417 h1:rhmVyijPfnbJ4deZaEpYS737VLO+H6Y6nTWLHMeqvVI=
+github.com/patsonluk/zk v1.0.3-0.20230615223655-b658df33d417/go.mod h1:ssbnU3H1lBdE6eTeQ4pyY53X+kHUNqwongLRP8AYygo=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/fullstorydev/zk v1.0.3-0.20200828191825-edfcb5d63fdd h1:0lubUEXk7T4Z4fJtam94F9IVGK/k/wFw7jjTMpX0Ke8=
-github.com/fullstorydev/zk v1.0.3-0.20200828191825-edfcb5d63fdd/go.mod h1:8fIOiu6/LYedHuzFUvyuLg0K2kFGSWGrEnsBytyZ9N4=
+github.com/patsonluk/zk v1.0.3-0.20230609180938-ecd7812130b6 h1:WyVmwrZEMo7UEcd1WoQvefQIdPIt31qrI7QUfUM1dZc=
+github.com/patsonluk/zk v1.0.3-0.20230609180938-ecd7812130b6/go.mod h1:ssbnU3H1lBdE6eTeQ4pyY53X+kHUNqwongLRP8AYygo=

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -1,32 +1,39 @@
 package solrmonitor
 
-/**
+/*
+*
 The client can register the SolrEventListener to listen to the solr cluster state events from the zookeeper.
 
 On startup, the events are fired in this order:
-	1. SolrLiveNodesChanged fires for all the solr live nodes (node which keeps indexes). It keeps watch on zk node /solr/live_nodes 's children
-	2. SolrQueryNodesChanged fires for all the solr query nodes (node which coordinates the query execution). It keeps watch on zk node /solr/live_query_nodes 's children
-	3. SolrCollectionsChanged fires for all collections that exist. It keeps watch on zk node /solr/collections 's children.
-		3.1 SolrCollectionStateChanged fires for each collection; keeps watch on zk node /solr/collections/collname/state.json
-		3.2 SolrCollectionReplicaStatesChanged fires if Per replica state(PRS) is enable for collection.
-			If PRS enable then it keeps watch on zk node /solr/collections/collname/state.json 's children. Those children represents state of each replica of collection
-			(reference https://issues.apache.org/jira/browse/SOLR-15052, https://docs.google.com/document/d/1xdxpzUNmTZbk0vTMZqfen9R3ArdHokLITdiISBxCFUg/edit )
+ 1. SolrLiveNodesChanged fires for all the solr live nodes (node which keeps indexes). It keeps watch on zk node /solr/live_nodes 's children
+ 2. SolrQueryNodesChanged fires for all the solr query nodes (node which coordinates the query execution). It keeps watch on zk node /solr/live_query_nodes 's children
+ 3. SolrCollectionsChanged fires for all collections that exist. It keeps watch on zk node /solr/collections 's children.
+    3.1 SolrCollectionStateChanged fires for each collection; keeps watch on zk node /solr/collections/collname/state.json
+    3.2 SolrCollectionReplicaStatesChanged fires if Per replica state(PRS) is enable for collection.
+    If PRS enable then it keeps watch on zk node /solr/collections/collname/state.json 's children. Those children represents state of each replica of collection
+    (reference https://issues.apache.org/jira/browse/SOLR-15052, https://docs.google.com/document/d/1xdxpzUNmTZbk0vTMZqfen9R3ArdHokLITdiISBxCFUg/edit )
 
 After initialization it delivers events for following condition
-	1. SolrLiveNodesChanged if solr live nodes changes
-	2. SolrQueryNodesChanged if solr query node changes
-	3. SolrCollectionsChanged if number of collections changes in solr cluster
-	4. SolrCollectionStateChanged if collection's number of shards changes, or replica moves, or replica splits.
-	5. SolrCollectionReplicaStatesChanged if collection's replica goes up/down, or becomes leader
 
-4. If collection get deleted - for non PRS
-	4.1 SolrCollectionStateChanged fires for collection's state.json, which get updated for each shard/replica
-	4.2	SolrCollectionStateChanged fires with all collections name except deleted collection.
-5. If collection get deleted - for PRS
-	5.1 following events happen
-		5.1.1 SolrCollectionStateChanged fires for collection's base state.json
-		5.1.2 SolrCollectionReplicaStatesChanged fires for all replicas/shards in collection
-	5.2 SolrCollectionsChanged fires with all collections name except deleted collection.
+ 1. SolrLiveNodesChanged if solr live nodes changes
+
+ 2. SolrQueryNodesChanged if solr query node changes
+
+ 3. SolrCollectionsChanged if number of collections changes in solr cluster
+
+ 4. SolrCollectionStateChanged if collection's number of shards changes, or replica moves, or replica splits.
+
+ 5. SolrCollectionReplicaStatesChanged if collection's replica goes up/down, or becomes leader
+
+ 4. If collection get deleted - for non PRS
+    4.1 SolrCollectionStateChanged fires for collection's state.json, which get updated for each shard/replica
+    4.2	SolrCollectionStateChanged fires with all collections name except deleted collection.
+
+ 5. If collection get deleted - for PRS
+    5.1 following events happen
+    5.1.1 SolrCollectionStateChanged fires for collection's base state.json
+    5.1.2 SolrCollectionReplicaStatesChanged fires for all replicas/shards in collection
+    5.2 SolrCollectionsChanged fires with all collections name except deleted collection.
 */
 type SolrEventListener interface {
 	// all the live nodes in the solr cluster
@@ -43,4 +50,7 @@ type SolrEventListener interface {
 
 	// collection replica state changed
 	SolrCollectionReplicaStatesChanged(name string, replicaStates map[string]*PerReplicaState)
+
+	//SolrCollectionReplicaStateDeleted(coll string, deletedReplicaState string)
+	//SolrCollectionReplicaStateAdded(coll string, newReplicaState *PerReplicaState)
 }

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -12,19 +12,23 @@ On startup, the events are fired in this order:
     3.2 SolrCollectionReplicaStatesChanged fires if Per replica state(PRS) is enable for collection.
     If PRS enable then it keeps watch on zk node /solr/collections/collname/state.json 's children. Those children represents state of each replica of collection
     (reference https://issues.apache.org/jira/browse/SOLR-15052, https://docs.google.com/document/d/1xdxpzUNmTZbk0vTMZqfen9R3ArdHokLITdiISBxCFUg/edit )
- 4. SolrClusterPropsChanged fires for the single clusterprops file
 
 After initialization it delivers events for following condition
+
  1. SolrLiveNodesChanged if solr live nodes changes
+
  2. SolrQueryNodesChanged if solr query node changes
+
  3. SolrCollectionsChanged if number of collections changes in solr cluster
+
  4. SolrCollectionStateChanged if collection's number of shards changes, or replica moves, or replica splits.
+
  5. SolrCollectionReplicaStatesChanged if collection's replica goes up/down, or becomes leader
- 6. SolrClusterPropsChanged if the cluster props are modified
 
  4. If collection get deleted - for non PRS
     4.1 SolrCollectionStateChanged fires for collection's state.json, which get updated for each shard/replica
     4.2	SolrCollectionStateChanged fires with all collections name except deleted collection.
+
  5. If collection get deleted - for PRS
     5.1 following events happen
     5.1.1 SolrCollectionStateChanged fires for collection's base state.json
@@ -46,7 +50,4 @@ type SolrEventListener interface {
 
 	// collection replica state changed
 	SolrCollectionReplicaStatesChanged(name string, replicaStates map[string]*PerReplicaState)
-
-	// cluster props changed
-	SolrClusterPropsChanged(clusterprops map[string]string)
 }

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -12,23 +12,19 @@ On startup, the events are fired in this order:
     3.2 SolrCollectionReplicaStatesChanged fires if Per replica state(PRS) is enable for collection.
     If PRS enable then it keeps watch on zk node /solr/collections/collname/state.json 's children. Those children represents state of each replica of collection
     (reference https://issues.apache.org/jira/browse/SOLR-15052, https://docs.google.com/document/d/1xdxpzUNmTZbk0vTMZqfen9R3ArdHokLITdiISBxCFUg/edit )
+ 4. SolrClusterPropsChanged fires for the single clusterprops file
 
 After initialization it delivers events for following condition
-
  1. SolrLiveNodesChanged if solr live nodes changes
-
  2. SolrQueryNodesChanged if solr query node changes
-
  3. SolrCollectionsChanged if number of collections changes in solr cluster
-
  4. SolrCollectionStateChanged if collection's number of shards changes, or replica moves, or replica splits.
-
  5. SolrCollectionReplicaStatesChanged if collection's replica goes up/down, or becomes leader
+ 6. SolrClusterPropsChanged if the cluster props are modified
 
  4. If collection get deleted - for non PRS
     4.1 SolrCollectionStateChanged fires for collection's state.json, which get updated for each shard/replica
     4.2	SolrCollectionStateChanged fires with all collections name except deleted collection.
-
  5. If collection get deleted - for PRS
     5.1 following events happen
     5.1.1 SolrCollectionStateChanged fires for collection's base state.json
@@ -50,4 +46,7 @@ type SolrEventListener interface {
 
 	// collection replica state changed
 	SolrCollectionReplicaStatesChanged(name string, replicaStates map[string]*PerReplicaState)
+
+	// cluster props changed
+	SolrClusterPropsChanged(clusterprops map[string]string)
 }

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -50,7 +50,4 @@ type SolrEventListener interface {
 
 	// collection replica state changed
 	SolrCollectionReplicaStatesChanged(name string, replicaStates map[string]*PerReplicaState)
-
-	//SolrCollectionReplicaStateDeleted(coll string, deletedReplicaState string)
-	//SolrCollectionReplicaStateAdded(coll string, newReplicaState *PerReplicaState)
 }

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -1,39 +1,32 @@
 package solrmonitor
 
-/*
-*
+/**
 The client can register the SolrEventListener to listen to the solr cluster state events from the zookeeper.
 
 On startup, the events are fired in this order:
- 1. SolrLiveNodesChanged fires for all the solr live nodes (node which keeps indexes). It keeps watch on zk node /solr/live_nodes 's children
- 2. SolrQueryNodesChanged fires for all the solr query nodes (node which coordinates the query execution). It keeps watch on zk node /solr/live_query_nodes 's children
- 3. SolrCollectionsChanged fires for all collections that exist. It keeps watch on zk node /solr/collections 's children.
-    3.1 SolrCollectionStateChanged fires for each collection; keeps watch on zk node /solr/collections/collname/state.json
-    3.2 SolrCollectionReplicaStatesChanged fires if Per replica state(PRS) is enable for collection.
-    If PRS enable then it keeps watch on zk node /solr/collections/collname/state.json 's children. Those children represents state of each replica of collection
-    (reference https://issues.apache.org/jira/browse/SOLR-15052, https://docs.google.com/document/d/1xdxpzUNmTZbk0vTMZqfen9R3ArdHokLITdiISBxCFUg/edit )
+	1. SolrLiveNodesChanged fires for all the solr live nodes (node which keeps indexes). It keeps watch on zk node /solr/live_nodes 's children
+	2. SolrQueryNodesChanged fires for all the solr query nodes (node which coordinates the query execution). It keeps watch on zk node /solr/live_query_nodes 's children
+	3. SolrCollectionsChanged fires for all collections that exist. It keeps watch on zk node /solr/collections 's children.
+		3.1 SolrCollectionStateChanged fires for each collection; keeps watch on zk node /solr/collections/collname/state.json
+		3.2 SolrCollectionReplicaStatesChanged fires if Per replica state(PRS) is enable for collection.
+			If PRS enable then it keeps watch on zk node /solr/collections/collname/state.json 's children. Those children represents state of each replica of collection
+			(reference https://issues.apache.org/jira/browse/SOLR-15052, https://docs.google.com/document/d/1xdxpzUNmTZbk0vTMZqfen9R3ArdHokLITdiISBxCFUg/edit )
 
 After initialization it delivers events for following condition
+	1. SolrLiveNodesChanged if solr live nodes changes
+	2. SolrQueryNodesChanged if solr query node changes
+	3. SolrCollectionsChanged if number of collections changes in solr cluster
+	4. SolrCollectionStateChanged if collection's number of shards changes, or replica moves, or replica splits.
+	5. SolrCollectionReplicaStatesChanged if collection's replica goes up/down, or becomes leader
 
- 1. SolrLiveNodesChanged if solr live nodes changes
-
- 2. SolrQueryNodesChanged if solr query node changes
-
- 3. SolrCollectionsChanged if number of collections changes in solr cluster
-
- 4. SolrCollectionStateChanged if collection's number of shards changes, or replica moves, or replica splits.
-
- 5. SolrCollectionReplicaStatesChanged if collection's replica goes up/down, or becomes leader
-
- 4. If collection get deleted - for non PRS
-    4.1 SolrCollectionStateChanged fires for collection's state.json, which get updated for each shard/replica
-    4.2	SolrCollectionStateChanged fires with all collections name except deleted collection.
-
- 5. If collection get deleted - for PRS
-    5.1 following events happen
-    5.1.1 SolrCollectionStateChanged fires for collection's base state.json
-    5.1.2 SolrCollectionReplicaStatesChanged fires for all replicas/shards in collection
-    5.2 SolrCollectionsChanged fires with all collections name except deleted collection.
+4. If collection get deleted - for non PRS
+	4.1 SolrCollectionStateChanged fires for collection's state.json, which get updated for each shard/replica
+	4.2	SolrCollectionStateChanged fires with all collections name except deleted collection.
+5. If collection get deleted - for PRS
+	5.1 following events happen
+		5.1.1 SolrCollectionStateChanged fires for collection's base state.json
+		5.1.2 SolrCollectionReplicaStatesChanged fires for all replicas/shards in collection
+	5.2 SolrCollectionsChanged fires with all collections name except deleted collection.
 */
 type SolrEventListener interface {
 	// all the live nodes in the solr cluster

--- a/solrmonitor/main/solrmonitor/solrmonitor.go
+++ b/solrmonitor/main/solrmonitor/solrmonitor.go
@@ -237,3 +237,24 @@ func (s *sexPantherZkCli) State() zk.State {
 func (s *sexPantherZkCli) Close() {
 	s.delegate.Close()
 }
+
+func (s *sexPantherZkCli) Children(path string) ([]string, *zk.Stat, error) {
+	if s.isFlaky() && s.rnd.Float32() > flakeChance {
+		return nil, nil, errors.New("flaky error")
+	}
+	return s.delegate.Children(path)
+}
+
+func (s *sexPantherZkCli) AddPersistentWatch(path string, mode zk.AddWatchMode) (ch zk.EventQueue, err error) {
+	if s.isFlaky() && s.rnd.Float32() > flakeChance {
+		return nil, errors.New("flaky error")
+	}
+	return s.delegate.AddPersistentWatch(path, mode)
+}
+
+func (s *sexPantherZkCli) RemoveAllPersistentWatches(path string) (err error) {
+	if s.isFlaky() && s.rnd.Float32() > flakeChance {
+		return errors.New("flaky error")
+	}
+	return s.delegate.RemoveAllPersistentWatches(path)
+}

--- a/solrmonitor/mock.go
+++ b/solrmonitor/mock.go
@@ -23,11 +23,11 @@ func newMockZkClient() ZkCli {
 type mockZkClient struct {
 }
 
-func (m mockZkClient) AddPersistentWatch(path string, mode zk.AddWatchMode) (ch zk.EventQueue, err error) {
+func (m mockZkClient) AddPersistentWatch(path string, mode zk.AddWatchMode) (ch *zk.EventQueueChannel, err error) {
 	panic("implement me")
 }
 
-func (m mockZkClient) RemovePersistentWatch(path string, ch zk.EventQueue) (err error) {
+func (m mockZkClient) RemoveAllPersistentWatches(path string) (err error) {
 	panic("implement me")
 }
 

--- a/solrmonitor/mock.go
+++ b/solrmonitor/mock.go
@@ -23,7 +23,7 @@ func newMockZkClient() ZkCli {
 type mockZkClient struct {
 }
 
-func (m mockZkClient) AddPersistentWatch(path string, mode zk.AddWatchMode) (ch *zk.EventQueueChannel, err error) {
+func (m mockZkClient) AddPersistentWatch(path string, mode zk.AddWatchMode) (ch zk.EventQueue, err error) {
 	panic("implement me")
 }
 

--- a/solrmonitor/mock.go
+++ b/solrmonitor/mock.go
@@ -23,6 +23,14 @@ func newMockZkClient() ZkCli {
 type mockZkClient struct {
 }
 
+func (m mockZkClient) AddPersistentWatch(path string, mode zk.AddWatchMode) (ch zk.EventQueue, err error) {
+	panic("implement me")
+}
+
+func (m mockZkClient) RemovePersistentWatch(path string, ch zk.EventQueue) (err error) {
+	panic("implement me")
+}
+
 func (m mockZkClient) ChildrenW(path string) ([]string, *zk.Stat, <-chan zk.Event, error) {
 	panic("Not implemented")
 }

--- a/solrmonitor/mock.go
+++ b/solrmonitor/mock.go
@@ -23,6 +23,11 @@ func newMockZkClient() ZkCli {
 type mockZkClient struct {
 }
 
+func (m mockZkClient) Children(path string) ([]string, *zk.Stat, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m mockZkClient) AddPersistentWatch(path string, mode zk.AddWatchMode) (ch zk.EventQueue, err error) {
 	panic("implement me")
 }

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -405,9 +405,9 @@ func (c *SolrMonitor) getCollFromPath(path string) *collection {
 
 func (c *SolrMonitor) getCollNameFromPath(path string) string {
 	//example inputs:
+	// <root>/collections/myCollection
 	// <root>/collections/myCollection/state.json
 	// <root>/collections/myCollection/state.json/some_prs
-	// <root>/collections/myCollection/state.json
 
 	name := strings.TrimPrefix(path, c.solrRoot+"/collections/")
 	stateStartIndex := strings.Index(name, "/state.json")

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -59,8 +59,8 @@ type ZkCli interface {
 	ExistsW(path string) (bool, *zk.Stat, <-chan zk.Event, error)
 	State() zk.State
 	Close()
-	AddPersistentWatch(path string, mode zk.AddWatchMode) (ch zk.EventQueue, err error)
-	RemovePersistentWatch(path string, ch zk.EventQueue) (err error)
+	AddPersistentWatch(path string, mode zk.AddWatchMode) (ch *zk.EventQueueChannel, err error)
+	RemoveAllPersistentWatches(path string) (err error)
 }
 
 // Create a new solrmonitor.  Solrmonitor takes ownership of the provided zkCli and zkWatcher-- they
@@ -683,6 +683,7 @@ func (coll *collection) start() error {
 func (coll *collection) stop() {
 	collPath := coll.parent.solrRoot + "/collections/" + coll.name
 	statePath := collPath + "/state.json"
+	coll.parent.zkWatcher.StopMonitorData(collPath)
 	coll.parent.zkWatcher.StopMonitorData(statePath)
 }
 

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -486,7 +486,7 @@ func (c *SolrMonitor) start() error {
 	if err := c.zkWatcher.MonitorData(rolesPath, false); err != nil {
 		return err
 	}
-	if err := c.zkWatcher.MonitorData(clusterPropsPath); err != nil {
+	if err := c.zkWatcher.MonitorData(clusterPropsPath, false); err != nil {
 		return err
 	}
 	return nil

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -59,7 +59,7 @@ type ZkCli interface {
 	ExistsW(path string) (bool, *zk.Stat, <-chan zk.Event, error)
 	State() zk.State
 	Close()
-	AddPersistentWatch(path string, mode zk.AddWatchMode) (ch *zk.EventQueueChannel, err error)
+	AddPersistentWatch(path string, mode zk.AddWatchMode) (ch zk.EventQueue, err error)
 	RemoveAllPersistentWatches(path string) (err error)
 }
 

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -436,7 +436,7 @@ func (c *SolrMonitor) start() error {
 	if err := c.zkWatcher.MonitorChildren(collectionsPath); err != nil {
 		return err
 	}
-	if err := c.zkWatcher.MonitorData(rolesPath); err != nil {
+	if err := c.zkWatcher.MonitorData(rolesPath, false); err != nil {
 		return err
 	}
 	return nil
@@ -607,11 +607,11 @@ func parseStateData(name string, data []byte, version int32) (*CollectionState, 
 func (coll *collection) start() error {
 	collPath := coll.parent.solrRoot + "/collections/" + coll.name
 	statePath := collPath + "/state.json"
-	if err := coll.parent.zkWatcher.MonitorData(collPath); err != nil { //for init
+	if err := coll.parent.zkWatcher.MonitorData(collPath, false); err != nil { //for init
 		return err
 	}
 
-	if err := coll.parent.zkWatcher.MonitorDataRecursive(statePath); err != nil {
+	if err := coll.parent.zkWatcher.MonitorData(statePath, true); err != nil {
 		return err
 	}
 

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -531,10 +531,10 @@ func (c *SolrMonitor) start() error {
 	if err := c.zkWatcher.MonitorChildren(collectionsPath); err != nil {
 		return err
 	}
-	if err := c.zkWatcher.MonitorData(rolesPath, false); err != nil {
+	if err := c.zkWatcher.MonitorData(rolesPath); err != nil {
 		return err
 	}
-	if err := c.zkWatcher.MonitorData(clusterPropsPath, false); err != nil {
+	if err := c.zkWatcher.MonitorData(clusterPropsPath); err != nil {
 		return err
 	}
 	return nil
@@ -717,11 +717,11 @@ func parseStateData(name string, data []byte, version int32) (*CollectionState, 
 func (coll *collection) start() error {
 	collPath := coll.parent.solrRoot + "/collections/" + coll.name
 	statePath := collPath + "/state.json"
-	if err := coll.parent.zkWatcher.MonitorData(collPath, false); err != nil { //for init
+	if err := coll.parent.zkWatcher.MonitorData(collPath); err != nil { //for init
 		return err
 	}
 
-	if err := coll.parent.zkWatcher.MonitorData(statePath, true); err != nil {
+	if err := coll.parent.zkWatcher.MonitorDataRecursive(statePath, 1); err != nil {
 		return err
 	}
 

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -110,19 +110,19 @@ func (c callbacks) ChildrenChanged(path string, children []string) error {
 }
 
 func (c callbacks) DataChanged(path string, data string, stat *zk.Stat) error {
+	if c.isPrsPath(path) { //special handling for PRS entry, since we are not fetching data on them
+		if stat.Version == -1 { //deletion
+			return c.SolrMonitor.pathDeleted(path)
+		} else {
+			return c.SolrMonitor.pathAdded(path)
+		}
+	}
+
 	version := int32(-1)
 	if stat != nil {
 		version = stat.Version
 	}
 	return c.SolrMonitor.dataChanged(path, data, version)
-}
-
-func (c callbacks) PathAdded(path string) error {
-	return c.SolrMonitor.pathAdded(path)
-}
-
-func (c callbacks) PathDeleted(path string) error {
-	return c.SolrMonitor.pathDeleted(path)
 }
 
 func (c callbacks) ShouldWatchChildren(path string) bool {

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -31,12 +32,13 @@ import (
 )
 
 type testutil struct {
-	t                 *testing.T
-	conn              *zk.Conn
-	root              string
-	sm                *SolrMonitor
-	logger            *smtestutil.ZkTestLogger
-	solrEventListener *SEListener
+	t                         *testing.T
+	conn                      *zk.Conn
+	root                      string
+	sm                        *SolrMonitor
+	logger                    *smtestutil.ZkTestLogger
+	solrEventListener         *SEListener
+	collectionStateFetchCount *atomic.Int32
 }
 
 func (tu *testutil) teardown() {
@@ -85,18 +87,26 @@ func setup(t *testing.T) (*SolrMonitor, *testutil) {
 		collStateEvents:  0,
 		collectionStates: make(map[string]*CollectionState),
 	}
-	sm, err := NewSolrMonitorWithRoot(conn, watcher, logger, root, l)
+
+	collectionStateFetchCount := &atomic.Int32{}
+	proxyZkClient := &proxyZkCli{
+		delegate:                  conn,
+		collectionStateFetchCount: collectionStateFetchCount,
+	}
+
+	sm, err := NewSolrMonitorWithRoot(proxyZkClient, watcher, logger, root, l)
 	if err != nil {
 		conn.Close()
 		t.Fatal(err)
 	}
 	return sm, &testutil{
-		t:                 t,
-		conn:              conn,
-		root:              root,
-		sm:                sm,
-		logger:            logger,
-		solrEventListener: l,
+		t:                         t,
+		conn:                      conn,
+		root:                      root,
+		sm:                        sm,
+		logger:                    logger,
+		solrEventListener:         l,
+		collectionStateFetchCount: collectionStateFetchCount,
 	}
 }
 
@@ -226,20 +236,22 @@ func TestCollectionChanges(t *testing.T) {
 }
 
 func TestPRSProtocol(t *testing.T) {
-	sm, testutil := setup(t)
-	defer testutil.teardown()
+	sm, testSetup := setup(t)
+	defer testSetup.teardown()
 
 	shouldNotExist(t, sm, "c1")
 
-	zkCli := testutil.conn
+	zkCli := testSetup.conn
 	zkCli.Create(sm.solrRoot+"/collections", nil, 0, zk.WorldACL(zk.PermAll))
 	_, err := zkCli.Create(sm.solrRoot+"/collections/c1", []byte(`{"configName":"_FS4"}`), 0, zk.WorldACL(zk.PermAll))
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	currentFetchCount := testSetup.collectionStateFetchCount
 	shouldNotExist(t, sm, "c1")
-	checkCollectionStateCallback(t, 1, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(t, 1, testSetup.solrEventListener.collStateEvents+testSetup.solrEventListener.collReplicaChangeEvents)
+	checkFetchCount(t, currentFetchCount, 2) //state.json fetch and 1 children fetch on PRS from coll.start()
 
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json", nil, 0, zk.WorldACL(zk.PermAll))
 	if err != nil {
@@ -247,9 +259,10 @@ func TestPRSProtocol(t *testing.T) {
 	}
 
 	shouldNotExist(t, sm, "c1")
-	checkCollectionStateCallback(t, 2, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(t, 2, testSetup.solrEventListener.collStateEvents+testSetup.solrEventListener.collReplicaChangeEvents)
+	checkFetchCount(t, currentFetchCount, 3) //state.json fetch from new state.json
 
-	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{\"perReplicaState\":\"true\",	 \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\"}}}}}}"), -1)
+	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{\"perReplicaState\":\"true\",	 \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\", \"state\":\"down\"}}}}}}"), -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,7 +275,8 @@ func TestPRSProtocol(t *testing.T) {
 	}
 
 	shouldExist(t, sm, "c1", collectionAssertions)
-	checkCollectionStateCallback(t, 3, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(t, 3, testSetup.solrEventListener.collStateEvents+testSetup.solrEventListener.collReplicaChangeEvents)
+	checkFetchCount(t, currentFetchCount, 4) //state.json fetch from updated state.json
 
 	// 1. adding PRS for replica R1, version 1, state down
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:1:D", nil, 0, zk.WorldACL(zk.PermAll))
@@ -270,38 +284,51 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1", "R1", "down", "false", 1)
-	checkCollectionStateCallback(t, 4, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(t, 4, testSetup.solrEventListener.collStateEvents+testSetup.solrEventListener.collReplicaChangeEvents)
 	// 2. adding PRS for replica R1, version 1 -same, state active => should ignore as same version
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:1:R", nil, 0, zk.WorldACL(zk.PermAll))
 	if err != nil {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1", "R1", "down", "false", 1)
-	checkCollectionStateCallback(t, 5, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(t, 5, testSetup.solrEventListener.collStateEvents+testSetup.solrEventListener.collReplicaChangeEvents)
 
 	// 3. adding PRS for replica R1, version 2, state active
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:2:A", nil, 0, zk.WorldACL(zk.PermAll))
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = zkCli.Delete(sm.solrRoot+"/collections/c1/state.json/R1:1:D", int32(-1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = zkCli.Delete(sm.solrRoot+"/collections/c1/state.json/R1:1:R", int32(-1))
+	if err != nil {
+		t.Fatal(err)
+	}
 	prsShouldExist(t, sm, "c1", "shard_1", "R1", "active", "false", 2)
-	checkCollectionStateCallback(t, 6, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(t, 6, testSetup.solrEventListener.collStateEvents+testSetup.solrEventListener.collReplicaChangeEvents)
 
 	// 4. adding PRS for replica R1, version 3, state active and leader
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:3:A:L", nil, 0, zk.WorldACL(zk.PermAll))
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = zkCli.Delete(sm.solrRoot+"/collections/c1/state.json/R1:2:A", int32(-1))
+	if err != nil {
+		t.Fatal(err)
+	}
 	prsShouldExist(t, sm, "c1", "shard_1", "R1", "active", "true", 3)
-	checkCollectionStateCallback(t, 7, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(t, 7, testSetup.solrEventListener.collStateEvents+testSetup.solrEventListener.collReplicaChangeEvents)
 
 	//5. split shard
-	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{\"perReplicaState\":\"true\",	 \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\"}}}, \"shard_1_0\":{\"replicas\":{\"R1_0\":{\"core\":\"core1\"}}}, \"shard_1_1\":{\"replicas\":{\"R1_1\":{\"core\":\"core1\"}}}}}}"), -1)
+	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json", []byte("{\"c1\":{\"perReplicaState\":\"true\",	 \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\", \"state\":\"down\"}}}, \"shard_1_0\":{\"replicas\":{\"R1_0\":{\"core\":\"core1\", \"state\":\"down\"}}}, \"shard_1_1\":{\"replicas\":{\"R1_1\":{\"core\":\"core1\", \"state\":\"down\"}}}}}}"), -1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(5000 * time.Millisecond)
-	checkCollectionStateCallback(t, 8, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(t, 8, testSetup.solrEventListener.collStateEvents+testSetup.solrEventListener.collReplicaChangeEvents)
+	checkFetchCount(t, currentFetchCount, 5) //state.json fetch from updated state.json
 
 	// 6. replica R1_0 should exist
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1_0:1:A:L", nil, 0, zk.WorldACL(zk.PermAll))
@@ -309,7 +336,7 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1_0", "R1_0", "active", "true", 1)
-	checkCollectionStateCallback(t, 9, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(t, 9, testSetup.solrEventListener.collStateEvents+testSetup.solrEventListener.collReplicaChangeEvents)
 
 	// 7. replica R1_1 should exist
 	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1_1:1:A:L", nil, 0, zk.WorldACL(zk.PermAll))
@@ -317,14 +344,52 @@ func TestPRSProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 	prsShouldExist(t, sm, "c1", "shard_1_1", "R1_1", "active", "true", 1)
-	checkCollectionStateCallback(t, 10, testutil.solrEventListener.collStateEvents+testutil.solrEventListener.collReplicaChangeEvents)
+	checkCollectionStateCallback(t, 10, testSetup.solrEventListener.collStateEvents+testSetup.solrEventListener.collReplicaChangeEvents)
 
-	if testutil.solrEventListener.collStateEvents != 4 || testutil.solrEventListener.collections != 1 {
-		t.Fatalf("Event listener didn't  not get event for collection  = %d, collectionstateEvents = %d", testutil.solrEventListener.collections, testutil.solrEventListener.collStateEvents)
+	if testSetup.solrEventListener.collStateEvents != 4 || testSetup.solrEventListener.collections != 1 {
+		t.Fatalf("Event listener didn't  not get event for collection  = %d, collectionstateEvents = %d", testSetup.solrEventListener.collections, testSetup.solrEventListener.collStateEvents)
 	}
 
 	// and after all of the updates, should still exist with same config name
 	shouldExist(t, sm, "c1", collectionAssertions)
+
+	//test on a brand new solrmonitor/conn with an existing collection, it should load correctly
+	logger := smtestutil.NewZkTestLogger(t)
+	watcher := NewZkWatcherMan(logger)
+	connOption := func(c *zk.Conn) { c.SetLogger(logger) }
+	fetchCount := &atomic.Int32{}
+
+	conn, _, err := zk.Connect([]string{"127.0.0.1:2181"}, time.Second*5, connOption, zk.WithEventCallback(watcher.EventCallback))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sm, err = NewSolrMonitorWithRoot(&proxyZkCli{conn, fetchCount}, watcher, logger, sm.solrRoot, nil) //make a new solrmonitor
+	if err != nil {
+		conn.Close()
+		t.Fatal(err)
+	}
+	collState, err := sm.GetCollectionState("c1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	replicaState := collState.Shards["shard_1"].Replicas["R1"]
+	if replicaState.State != "active" {
+		t.Fatalf("Expected replica R1 state active but found %s", replicaState.State)
+	}
+	if replicaState.Leader != "true" {
+		t.Fatalf("Expected replica R1 leadership but found %s", replicaState.Leader)
+	}
+	if replicaState.Version != 3 {
+		t.Fatalf("Expected replica R1 version 3 but found %v", replicaState.Version)
+	}
+	//For brevity, just check states for child shards
+	if collState.Shards["shard_1_0"].Replicas["R1_0"].State != "active" {
+		t.Fatalf("Expected replica R1_0 state active, but it's not")
+	}
+	if collState.Shards["shard_1_1"].Replicas["R1_1"].State != "active" {
+		t.Fatalf("Expected replica R1_1 state active, but it's not")
+	}
+	checkFetchCount(t, fetchCount, 2) //state.json fetch and 1 children fetch on PRS from coll.start()
 }
 
 func checkCollectionStateCallback(t *testing.T, expected int, found int) {
@@ -392,4 +457,60 @@ func (l *SEListener) SolrCollectionReplicaStatesChanged(name string, replicaStat
 
 func (l *SEListener) SolrClusterPropsChanged(clusterprops map[string]string) {
 	l.clusterPropChangeEvents++
+}
+
+// proxyZkCli to ensure the zk collection state fetch count is as expected
+type proxyZkCli struct {
+	delegate                  ZkCli
+	collectionStateFetchCount *atomic.Int32 //fetches on collection state.json including PRS entries
+}
+
+var _ ZkCli = &proxyZkCli{}
+
+func (p *proxyZkCli) Children(path string) ([]string, *zk.Stat, error) {
+	if strings.Contains(path, "/state.json") {
+		p.collectionStateFetchCount.Add(1)
+	}
+	return p.delegate.Children(path)
+}
+
+func (p *proxyZkCli) ChildrenW(path string) ([]string, *zk.Stat, <-chan zk.Event, error) {
+	if strings.Contains(path, "/state.json") {
+		p.collectionStateFetchCount.Add(1)
+	}
+	return p.delegate.ChildrenW(path)
+}
+
+func (p *proxyZkCli) Get(path string) ([]byte, *zk.Stat, error) {
+	if strings.Contains(path, "/state.json") {
+		p.collectionStateFetchCount.Add(1)
+	}
+	return p.delegate.Get(path)
+}
+
+func (p *proxyZkCli) GetW(path string) ([]byte, *zk.Stat, <-chan zk.Event, error) {
+	if strings.Contains(path, "/state.json") {
+		p.collectionStateFetchCount.Add(1)
+	}
+	return p.delegate.GetW(path)
+}
+
+func (p *proxyZkCli) ExistsW(path string) (bool, *zk.Stat, <-chan zk.Event, error) {
+	return p.delegate.ExistsW(path)
+}
+
+func (p *proxyZkCli) State() zk.State {
+	return p.delegate.State()
+}
+
+func (p *proxyZkCli) Close() {
+	p.delegate.Close()
+}
+
+func (p *proxyZkCli) AddPersistentWatch(path string, mode zk.AddWatchMode) (ch zk.EventQueue, err error) {
+	return p.delegate.AddPersistentWatch(path, mode)
+}
+
+func (p *proxyZkCli) RemoveAllPersistentWatches(path string) (err error) {
+	return p.delegate.RemoveAllPersistentWatches(path)
 }

--- a/solrmonitor/util_test.go
+++ b/solrmonitor/util_test.go
@@ -1,6 +1,7 @@
 package solrmonitor
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -107,6 +108,23 @@ func prsShouldExist(t *testing.T, sm *SolrMonitor, name string, shard string, re
 	}
 
 	t.Fatalf("expected collection %s 's replica updated", name)
+}
+
+func checkFetchCount(t *testing.T, currentFetchCount *atomic.Int32, expectedFetchCount int32) {
+	t.Helper()
+	// Wait a moment before checking, otherwise it might not flag when there are too many fetches
+	time.Sleep(200 * time.Millisecond)
+	for end := time.Now().Add(checkTimeout); time.Now().Before(end); {
+		if currentFetchCount.Load() > expectedFetchCount {
+			t.Fatalf("fetch count %v exceeded expected count %v", currentFetchCount.Load(), expectedFetchCount)
+			return
+		}
+		if currentFetchCount.Load() == expectedFetchCount {
+			return
+		}
+		time.Sleep(checkInterval)
+	}
+	t.Fatalf("fetch count %v is not equal to expected count %v", currentFetchCount.Load(), expectedFetchCount)
 }
 
 func shouldNotExist(t *testing.T, sm *SolrMonitor, name string) {

--- a/solrmonitor/zkwatcherman.go
+++ b/solrmonitor/zkwatcherman.go
@@ -301,7 +301,7 @@ func getChildrenAndWatch(zkCli ZkCli, path string) ([]string, <-chan zk.Event, e
 	}
 }
 
-func (m *ZkWatcherMan) addPersistentWatch(path string, recursive bool) (<-chan zk.Event, error) {
+func (m *ZkWatcherMan) addPersistentWatch(path string, recursive bool) (zk.EventQueue, error) {
 	var addWatchMode zk.AddWatchMode
 	if recursive {
 		addWatchMode = zk.AddWatchModePersistentRecursive
@@ -314,5 +314,5 @@ func (m *ZkWatcherMan) addPersistentWatch(path string, recursive bool) (<-chan z
 	if err != nil {
 		return nil, err
 	}
-	return eventQueue.Chan, err
+	return eventQueue, err
 }

--- a/solrmonitor/zkwatcherman.go
+++ b/solrmonitor/zkwatcherman.go
@@ -37,8 +37,7 @@ type deferredChildrenTask struct {
 
 // A MonitorData request whose last attempt to set a watch failed.
 type deferredDataTask struct {
-	path      string
-	recursive bool
+	path string
 }
 
 // Helper class to continuously monitor nodes for state or data changes.
@@ -77,18 +76,18 @@ func (m *ZkWatcherMan) EventCallback(evt zk.Event) {
 	case zk.EventNodeCreated, zk.EventNodeDeleted:
 		// Just enqueue both kinds of tasks, we might throw one away later.
 		m.logger.Printf("ZkWatcherMan %s: %s", evt.Type, evt.Path)
-		m.enqueueDeferredTask(deferredDataTask{evt.Path, false}) //TODO probably not care as we do not need to reinstall if watch is permanent
+		m.enqueueDeferredTask(deferredDataTask{evt.Path})
 		m.enqueueDeferredTask(deferredChildrenTask{evt.Path})
 	case zk.EventNodeDataChanged:
 		m.logger.Printf("ZkWatcherMan data %s: %s", evt.Type, evt.Path)
-		m.enqueueDeferredTask(deferredDataTask{evt.Path, false}) //TODO
+		m.enqueueDeferredTask(deferredDataTask{evt.Path})
 	case zk.EventNodeChildrenChanged:
 		m.logger.Printf("ZkWatcherMan children %s: %s", evt.Type, evt.Path)
 		m.enqueueDeferredTask(deferredChildrenTask{evt.Path})
 	case zk.EventNotWatching:
 		// Lost ZK session; we'll need to re-register all watches when it comes back.
 		// Just enqueue both kinds of tasks, we might throw them away later.
-		m.enqueueDeferredTask(deferredDataTask{evt.Path, false}) //TODO
+		m.enqueueDeferredTask(deferredDataTask{evt.Path})
 		m.enqueueDeferredTask(deferredChildrenTask{evt.Path})
 	default:
 		if evt.Err == zk.ErrClosing {

--- a/solrmonitor/zkwatcherman.go
+++ b/solrmonitor/zkwatcherman.go
@@ -26,8 +26,6 @@ import (
 type Callbacks interface {
 	ChildrenChanged(path string, children []string) error
 	DataChanged(path string, data string, stat *zk.Stat) error
-	PathAdded(path string) error
-	PathDeleted(path string) error
 	ShouldWatchChildren(path string) bool
 	ShouldWatchData(path string) bool
 	ShouldFetchData(path string) bool //whether we need to fetch the data from the node along with the stat, in some cases, knowing just the path and whether it's a deletion are good enough
@@ -84,9 +82,9 @@ func (m *ZkWatcherMan) EventCallback(evt zk.Event) {
 			m.enqueueDeferredTask(deferredChildrenTask{evt.Path})
 		} else { //all data watch are permanent, all we need to do is notify the callback
 			if evt.Type == zk.EventNodeCreated {
-				m.callbacks.PathAdded(evt.Path)
+				m.callbacks.DataChanged(evt.Path, "", &zk.Stat{Version: 1})
 			} else {
-				m.callbacks.PathDeleted(evt.Path)
+				m.callbacks.DataChanged(evt.Path, "", &zk.Stat{Version: -1})
 			}
 		}
 	case zk.EventNodeDataChanged:


### PR DESCRIPTION
## Description
POC to assess scope of change/challenges to implement solrmonitor/solrman to make use of the recursive persistent watch.

Since Apache zk v3.6. A new class of watch is introduced which can be [persistent and/or recursive](https://zookeeper.apache.org/doc/current/zookeeperProgrammers.html#sc_WatchPersistentRecursive
).

Before such class of watch, if we want to keep watching a particular data node (as implemented in zkwatcherman for example), we would:
1. call getW() on such node path, which installs a one-time watch on such path
2. If the node has any changes (data change, deletion, addition), we would be notified by zk.Event, then we call getW() again to fetch the actual update (since zk.Event does NOT contain the data) as well as re-installing a new one-time watch

For watching children of a particular node (for example state.json for PRS), it's very similar:
1. call childrenW() on the path (which only returns the child paths, not the data of them), which installs a one-time children watch on it
2. if there are any child changes (deletion, addition), we would be notified by a `EventNodeChildrenChanged` event, then we call childrenW() again to get the list of children paths and re-install the watch

With permanent watch, we will still NEED to fetch the data again, just that we can call `get()` instead of `getW()`

Now recursive watch HAS to be permanent as well. It can become a replacement of data + children watch, more importantly, it could reduce the number of fetch and amount of data tranferred. For example, if we want to watch the child change of `state.json`. And assume there's a new child entry added, and then a old child entry removed:
- For old watch, we will need to add a children watch on `state.json`, on first child entry addition, we will need to call `childrenW()` to get the full list of child paths, and then again on child deletion.
- For persistent and recursive watch, on first child entry addition, we no longer need to fetch the full child path list and the path version is a part of the path, and it's similar for deletion. Take note that we might need to keep the state of the child paths.

## Solution
For the zk goclient, there's [an open PR](https://github.com/go-zookeeper/zk/pull/89) (lacking reviews unfortunately) that implements it. Therefore we have cherry picked those changes into https://github.com/patsonluk/zk/commits/cherry-pick-persistent-watch

Now there are 2 major consumers of zk goclient:
1. solrmonitor via zkwatcherman
2. solrman. Which uses zkcli directly for monitoring live nodes, qa nodes and overseer leader. It also uses solrmonitor library to get collection states

This POC in particular focuses on replacing PRS monitoring in solrmonitor/zkwatcherman with permanent recursive watch, which has the best potential for performance improvement. (reduce fetches)

A new branch of gosolr is created https://github.com/fullstorydev/gosolr/tree/patsonluk/zk-persistent-watch that modifies the collections state/PRS monitoring. For each collection, instead of adding a data watch + children watch on state.json. it will only install a single permanent recursive watch. And instead of fetching full child path and updating the collections state with all the entries, it will use the path provided in the zkEvent (so no extra fetching) and update the collection state with it.

solrmonitor should no longer rely on `ChildrenChanged` for PRS updates, instead it will rely on `DataChanged` to be notified of PRS entry changes. There's also a new `ShouldFetchData` function, which would return false for PRS entry, this signals zkwatcherman to NOT fetch the data on zk.EventNodeCreated and zk.EventNodeDeleted as we only care about the path for PRS. 

Also zkwatcherman needs special handling for recursive monitoring. For non-recursive monitoring, zkwatcherman always fetches the path (whether `get` and `children`) and knows the exact path to fetch. However, for recursive monitoring, it will need to recursively fetch all the children. This however, can be costly (n extra children fetch, which n is # of PRS entries), in the new function `MonitorDataRecursive`, a parameter `initFetchDepth` is  added to indicate how deep should the children be fetched for init.

To avoid changes to the higher level `SolrEventListener`, we will still maintain the existing `SolrCollectionReplicaStatesChanged(name string, replicaStates map[string]*PerReplicaState)` function even for single PRS entry changes (not any worse than before, as n child changes should result as n childrenWatch events before)


# Tests
Added extra test into the existing `TestPRSProtocol`:
1. Added fetch count verification on state.json and PRS entries. This is to verify persistent watch does reduce # of fetch for PRS operations
2. Added a new case to ensure fetched collection/PRS state is correct on existing collection (before solrmonitor starts monitoring it). This is critical as the initial fetch logic on persistent watch is tricky (need to recursively fetch path)

Tested locally with both solrman and solrmonitor referencing the new gosolr hash on https://github.com/fullstorydev/gosolr/commits/patsonluk/zk-persistent-watch . Test operations such as split to ensure it works. 

Also wanted to test on solrmonitor (the gosolr) one with `--flaky` flag, however, it turns out that such flag is only used post init: https://github.com/fullstorydev/gosolr/blob/25ddda1de200ce73744493278393e1f1e433f557/solrmonitor/main/solrmonitor/solrmonitor.go#L90, and if we make changes in ZK directly to simulate PRS update, there're no longer any data/children fetching for PRS- as it only reads the PRS path update from notification now (zk.Event)

# TODO
This POC focuses only on replacing PRS related zk ops. Therefore only `zkwatcherman.MonitorData` has been modified (to support recursive watching). Other operations such as cluster props or children watch on collections/live nodes remain the same. Take note that `zkwatcherman.MonitorChildren` is also unchanged - it's still a one-time watch.

This assumes ALL watches on `zkwatcherman.MonitorData` are persistent, it is tricky to allow a switch as based on whether the watch is persistent, the `zkwatcherman.Callbacks` provided by the caller (in this case by solrmonitor) might need to be changed (for example ShouldWatchChildren and ShouldWatchData) as well. Keeping it simple for POC
 


