### PR TITLE
Removed ReplicationFactor prop from collectionState

### DIFF
--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -32,7 +32,7 @@ type CollectionState struct {
 }
 
 func (cs *CollectionState) String() string {
-	return fmt.Sprintf("CollectionState\n{Shards:%+v, PerReplicaState:%s}\n", cs.Shards, true)
+	return fmt.Sprintf("CollectionState\n{Shards:%+v}\n", cs.Shards)
 }
 
 func (cs *CollectionState) isPRSEnabled() bool {

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -21,7 +21,7 @@ type CollectionState struct {
 	Router           Router                 `json:"router"`           // e.g. {"name":"compositeId"}
 	MaxShardsPerNode string                 `json:"maxShardsPerNode"` // e.g. "1" (yes, these are strings, not numbers)
 	AutoAddReplicas  string                 `json:"autoAddReplicas"`  // e.g. "false" (yes, these are strings, not bools)
-	PerReplicaState  string                 `json:"perReplicaState"`  // whether collection keeps state for each replica separately
+	PerReplicaState  bool                   `json:"perReplicaState"`  // whether collection keeps state for each replica separately
 
 	// These following fields are set manually, not from state.json in Zookeeper.
 
@@ -37,7 +37,7 @@ func (cs *CollectionState) String() string {
 }
 
 func (cs *CollectionState) isPRSEnabled() bool {
-	return cs.PerReplicaState == "true"
+	return cs.PerReplicaState
 }
 
 // zkCollectionState is used to parse top level collection zk nodes.

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -21,7 +21,6 @@ type CollectionState struct {
 	Router           Router                 `json:"router"`           // e.g. {"name":"compositeId"}
 	MaxShardsPerNode string                 `json:"maxShardsPerNode"` // e.g. "1" (yes, these are strings, not numbers)
 	AutoAddReplicas  string                 `json:"autoAddReplicas"`  // e.g. "false" (yes, these are strings, not bools)
-	PerReplicaState  bool                   `json:"perReplicaState"`  // whether collection keeps state for each replica separately
 
 	// These following fields are set manually, not from state.json in Zookeeper.
 
@@ -33,11 +32,11 @@ type CollectionState struct {
 }
 
 func (cs *CollectionState) String() string {
-	return fmt.Sprintf("CollectionState\n{Shards:%+v, PerReplicaState:%s}\n", cs.Shards, cs.PerReplicaState)
+	return fmt.Sprintf("CollectionState\n{Shards:%+v, PerReplicaState:%s}\n", cs.Shards, true)
 }
 
 func (cs *CollectionState) isPRSEnabled() bool {
-	return cs.PerReplicaState
+	return true
 }
 
 // zkCollectionState is used to parse top level collection zk nodes.

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -35,7 +35,7 @@ func (cs *CollectionState) String() string {
 	return fmt.Sprintf("CollectionState\n{Shards:%+v}\n", cs.Shards)
 }
 
-func (cs *CollectionState) isPRSEnabled() bool {
+func (cs *CollectionState) IsPRSEnabled() bool {
 	return true
 }
 

--- a/solrmonitor/collectionstate.go
+++ b/solrmonitor/collectionstate.go
@@ -17,12 +17,11 @@ package solrmonitor
 import "fmt"
 
 type CollectionState struct {
-	Shards            map[string]*ShardState `json:"shards"`            // map from shard name to shard state
-	ReplicationFactor string                 `json:"replicationFactor"` // e.g. "1" (yes, these are strings, not numbers)
-	Router            Router                 `json:"router"`            // e.g. {"name":"compositeId"}
-	MaxShardsPerNode  string                 `json:"maxShardsPerNode"`  // e.g. "1" (yes, these are strings, not numbers)
-	AutoAddReplicas   string                 `json:"autoAddReplicas"`   // e.g. "false" (yes, these are strings, not bools)
-	PerReplicaState   string                 `json:"perReplicaState"`   // whether collection keeps state for each replica separately
+	Shards           map[string]*ShardState `json:"shards"`           // map from shard name to shard state
+	Router           Router                 `json:"router"`           // e.g. {"name":"compositeId"}
+	MaxShardsPerNode string                 `json:"maxShardsPerNode"` // e.g. "1" (yes, these are strings, not numbers)
+	AutoAddReplicas  string                 `json:"autoAddReplicas"`  // e.g. "false" (yes, these are strings, not bools)
+	PerReplicaState  string                 `json:"perReplicaState"`  // whether collection keeps state for each replica separately
 
 	// These following fields are set manually, not from state.json in Zookeeper.
 

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -752,7 +752,7 @@ func (coll *collection) setStateData(data string, version int32) *CollectionStat
 }
 
 func (coll *collection) updateReplicaVersionAndState(newState *CollectionState, oldState *CollectionState) {
-	if oldState == nil || newState == nil || !newState.isPRSEnabled() {
+	if oldState == nil || newState == nil || !newState.IsPRSEnabled() {
 		return
 	}
 	for shradName, newShardState := range newState.Shards {
@@ -808,5 +808,5 @@ func (coll *collection) hasWatch() bool {
 func (coll *collection) isPRSEnabled() bool {
 	coll.mu.RLock()
 	defer coll.mu.RUnlock()
-	return coll.collectionState != nil && coll.collectionState.isPRSEnabled()
+	return coll.collectionState != nil && coll.collectionState.IsPRSEnabled()
 }

--- a/solrmonitor/util_test.go
+++ b/solrmonitor/util_test.go
@@ -80,7 +80,7 @@ func prsShouldExist(t *testing.T, sm *SolrMonitor, name string, shard string, re
 				continue
 			}
 
-			if !val.isPRSEnabled() {
+			if !val.IsPRSEnabled() {
 				t.Errorf("expected collection %s to be PRS", name)
 				continue
 			}


### PR DESCRIPTION
In solr 93 type of following collection properties has been changed. In general, we don't use these properties thus removing for time being. Once we will move from solr92 to solr93, we will add that back.
1. replicationFactor changed from string to int
2. perReplicaState changed from string to bool

I have tested this with solr92 and solr93