### PR TITLE
Add a flag includeSysCol (default as fault) to control whether system collections should be included in the handling

### DIFF
--- a/solrmonitor/main/solrmonitor/solrmonitor.go
+++ b/solrmonitor/main/solrmonitor/solrmonitor.go
@@ -79,7 +79,7 @@ func run(logger *log.Logger) error {
 		zkCli = flakyZk
 	}
 
-	solrMonitor, err := solrmonitor.NewSolrMonitorWithRoot(zkCli, zkWatcher, &solrmonitorLogger{logger: logger}, solrZkPath, nil)
+	solrMonitor, err := solrmonitor.NewSolrMonitorWithRoot(zkCli, zkWatcher, &solrmonitorLogger{logger: logger}, solrZkPath, false, nil)
 	if err != nil {
 		return smutil.Cherrf(err, "Failed to create solrMonitor")
 	}


### PR DESCRIPTION
## Description
It's found in various scenarios that system collections (eg `.sys.COORDINATOR-COLL-_FS7`) have triggered unexpected handling on higher level logic which does not expect such collection.

Therefore we are adding an init flag `includeSysCol` , and by default we will ignore those system collections with prefix `.sys.`