### PR TITLE
remove zk watching for live_query_nodes and listener

### DIFF
--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -5,13 +5,12 @@ The client can register the SolrEventListener to listen to the solr cluster stat
 
 On startup, the events are fired in this order:
  1. SolrLiveNodesChanged fires for all the solr live nodes (node which keeps indexes). It keeps watch on zk node /solr/live_nodes 's children
- 2. SolrQueryNodesChanged fires for all the solr query nodes (node which coordinates the query execution). It keeps watch on zk node /solr/live_query_nodes 's children
- 3. SolrCollectionsChanged fires for all collections that exist. It keeps watch on zk node /solr/collections 's children.
+ 2. SolrCollectionsChanged fires for all collections that exist. It keeps watch on zk node /solr/collections 's children.
     3.1 SolrCollectionStateChanged fires for each collection; keeps watch on zk node /solr/collections/collname/state.json
     3.2 SolrCollectionReplicaStatesChanged fires if Per replica state(PRS) is enable for collection.
     If PRS enable then it keeps watch on zk node /solr/collections/collname/state.json 's children. Those children represents state of each replica of collection
     (reference https://issues.apache.org/jira/browse/SOLR-15052, https://docs.google.com/document/d/1xdxpzUNmTZbk0vTMZqfen9R3ArdHokLITdiISBxCFUg/edit )
- 4. SolrClusterPropsChanged fires for the single clusterprops file
+ 3. SolrClusterPropsChanged fires for the single clusterprops file
 
 After initialization it delivers events for following condition
 
@@ -40,9 +39,6 @@ After initialization it delivers events for following condition
 type SolrEventListener interface {
 	// all the live nodes in the solr cluster
 	SolrLiveNodesChanged(livenodes []string)
-
-	// all the query aggregator nodes in ths solr cluster
-	SolrQueryNodesChanged(querynodes []string)
 
 	// all the collections in the solr cluster
 	SolrCollectionsChanged(collections []string)

--- a/solrmonitor/SolrEventListener.go
+++ b/solrmonitor/SolrEventListener.go
@@ -6,8 +6,8 @@ The client can register the SolrEventListener to listen to the solr cluster stat
 On startup, the events are fired in this order:
  1. SolrLiveNodesChanged fires for all the solr live nodes (node which keeps indexes). It keeps watch on zk node /solr/live_nodes 's children
  2. SolrCollectionsChanged fires for all collections that exist. It keeps watch on zk node /solr/collections 's children.
-    3.1 SolrCollectionStateChanged fires for each collection; keeps watch on zk node /solr/collections/collname/state.json
-    3.2 SolrCollectionReplicaStatesChanged fires if Per replica state(PRS) is enable for collection.
+    2.1 SolrCollectionStateChanged fires for each collection; keeps watch on zk node /solr/collections/collname/state.json
+    2.2 SolrCollectionReplicaStatesChanged fires if Per replica state(PRS) is enable for collection.
     If PRS enable then it keeps watch on zk node /solr/collections/collname/state.json 's children. Those children represents state of each replica of collection
     (reference https://issues.apache.org/jira/browse/SOLR-15052, https://docs.google.com/document/d/1xdxpzUNmTZbk0vTMZqfen9R3ArdHokLITdiISBxCFUg/edit )
  3. SolrClusterPropsChanged fires for the single clusterprops file

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -80,7 +80,6 @@ func setup(t *testing.T) (*SolrMonitor, *testutil) {
 
 	l := &SEListener{
 		liveNodes:        0,
-		queryNodes:       0,
 		collections:      0,
 		collStateEvents:  0,
 		collectionStates: make(map[string]*CollectionState),
@@ -207,8 +206,8 @@ func TestCollectionChanges(t *testing.T) {
 		t.Fatalf("Event listener didn't  not get event for collection  = %d, collectionstate = %d", testutil.solrEventListener.collections, len(testutil.solrEventListener.collectionStates))
 	}
 
-	if testutil.solrEventListener.liveNodes != 1 || testutil.solrEventListener.queryNodes != 1 {
-		t.Fatalf("Event listener didn't  not get event for livenodes  = %d, querynodes = %d", testutil.solrEventListener.liveNodes, testutil.solrEventListener.queryNodes)
+	if testutil.solrEventListener.liveNodes != 1 {
+		t.Fatalf("Event listener didn't  not get event for livenodes  = %d ", testutil.solrEventListener.liveNodes)
 	}
 
 	// Get a fresh new solr monitor and make sure it starts in the right state.
@@ -395,7 +394,6 @@ func DisabledTestBadStateJson(t *testing.T) {
 
 type SEListener struct {
 	liveNodes               int
-	queryNodes              int
 	collections             int
 	collStateEvents         int
 	collReplicaChangeEvents int
@@ -405,10 +403,6 @@ type SEListener struct {
 
 func (l *SEListener) SolrLiveNodesChanged(livenodes []string) {
 	l.liveNodes = len(livenodes)
-}
-
-func (l *SEListener) SolrQueryNodesChanged(querynodes []string) {
-	l.queryNodes = len(querynodes)
 }
 
 func (l *SEListener) SolrCollectionsChanged(collections []string) {


### PR DESCRIPTION
We don't need this as we have new functionality `coordinator` nodes, which are part of live nodes. This callback is causing issue with our go-services, as it resets query nodes to empty