### PR TITLE
SAI-5104 : provide option to ignore collections with certain suffixes

### DIFF
--- a/solrmonitor/main/solrmonitor/solrmonitor.go
+++ b/solrmonitor/main/solrmonitor/solrmonitor.go
@@ -79,7 +79,7 @@ func run(logger *log.Logger) error {
 		zkCli = flakyZk
 	}
 
-	solrMonitor, err := solrmonitor.NewSolrMonitorWithRoot(zkCli, zkWatcher, &solrmonitorLogger{logger: logger}, solrZkPath, false, nil)
+	solrMonitor, err := solrmonitor.NewSolrMonitorWithRoot(zkCli, zkWatcher, &solrmonitorLogger{logger: logger}, solrZkPath, []string{solrmonitor.SysColPrefix}, nil, nil)
 	if err != nil {
 		return smutil.Cherrf(err, "Failed to create solrMonitor")
 	}

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -66,18 +66,15 @@ type ZkCli interface {
 // will be closed when Solrmonitor is closed, and should not be used by any other caller.
 // The provided zkWatcher must already be wired to the associated zkCli to receive all global events.
 func NewSolrMonitor(zkCli ZkCli, ignoreSuffixes []string, zkWatcher *ZkWatcherMan) (*SolrMonitor, error) {
-	return NewSolrMonitorWithLogger(zkCli, zkWatcher, zk.DefaultLogger, true, ignoreSuffixes, nil) // ignore sys collections by default
+	return NewSolrMonitorWithLogger(zkCli, zkWatcher, zk.DefaultLogger, ignoreSuffixes, nil)
 }
 
 // Create a new solrmonitor.  Solrmonitor takes ownership of the provided zkCli and zkWatcher-- they
 // will be closed when Solrmonitor is closed, and should not be used by any other caller.
 // The provided zkWatcher must already be wired to the associated zkCli to receive all global events.
-func NewSolrMonitorWithLogger(zkCli ZkCli, zkWatcher *ZkWatcherMan, logger zk.Logger, ignoreSysCol bool, ignoreSuffixes []string, solrEventListener SolrEventListener) (*SolrMonitor, error) {
-	var ignorePrefixes []string
-	if ignoreSysCol {
-		ignorePrefixes = []string{sysColPrefix}
-	}
-	return NewSolrMonitorWithRoot(zkCli, zkWatcher, logger, "/solr", ignorePrefixes, ignoreSuffixes, solrEventListener)
+func NewSolrMonitorWithLogger(zkCli ZkCli, zkWatcher *ZkWatcherMan, logger zk.Logger, ignoreSuffixes []string, solrEventListener SolrEventListener) (*SolrMonitor, error) {
+	//ignore system collections by default
+	return NewSolrMonitorWithRoot(zkCli, zkWatcher, logger, "/solr", []string{sysColPrefix}, ignoreSuffixes, solrEventListener)
 }
 
 // Create a new solrmonitor.  Solrmonitor takes ownership of the provided zkCli and zkWatcher-- they

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -31,7 +31,7 @@ const (
 	liveNodesPath    = "/live_nodes"
 	rolesPath        = "/roles.json"
 	clusterPropsPath = "/clusterprops.json"
-	sysColPrefix     = ".sys."
+	SysColPrefix     = ".sys."
 )
 
 // Keeps an in-memory copy of the current state of the Solr cluster; automatically updates on ZK changes.
@@ -74,7 +74,7 @@ func NewSolrMonitor(zkCli ZkCli, ignoreSuffixes []string, zkWatcher *ZkWatcherMa
 // The provided zkWatcher must already be wired to the associated zkCli to receive all global events.
 func NewSolrMonitorWithLogger(zkCli ZkCli, zkWatcher *ZkWatcherMan, logger zk.Logger, ignoreSuffixes []string, solrEventListener SolrEventListener) (*SolrMonitor, error) {
 	//ignore system collections by default
-	return NewSolrMonitorWithRoot(zkCli, zkWatcher, logger, "/solr", []string{sysColPrefix}, ignoreSuffixes, solrEventListener)
+	return NewSolrMonitorWithRoot(zkCli, zkWatcher, logger, "/solr", []string{SysColPrefix}, ignoreSuffixes, solrEventListener)
 }
 
 // Create a new solrmonitor.  Solrmonitor takes ownership of the provided zkCli and zkWatcher-- they

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -66,7 +66,7 @@ type ZkCli interface {
 // will be closed when Solrmonitor is closed, and should not be used by any other caller.
 // The provided zkWatcher must already be wired to the associated zkCli to receive all global events.
 func NewSolrMonitor(zkCli ZkCli, ignoreSuffixes []string, zkWatcher *ZkWatcherMan) (*SolrMonitor, error) {
-	return NewSolrMonitorWithLogger(zkCli, zkWatcher, zk.DefaultLogger, true, nil, nil) // ignore sys collections by default
+	return NewSolrMonitorWithLogger(zkCli, zkWatcher, zk.DefaultLogger, true, ignoreSuffixes, nil) // ignore sys collections by default
 }
 
 // Create a new solrmonitor.  Solrmonitor takes ownership of the provided zkCli and zkWatcher-- they

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -65,14 +65,18 @@ type ZkCli interface {
 // Create a new solrmonitor.  Solrmonitor takes ownership of the provided zkCli and zkWatcher-- they
 // will be closed when Solrmonitor is closed, and should not be used by any other caller.
 // The provided zkWatcher must already be wired to the associated zkCli to receive all global events.
-func NewSolrMonitor(zkCli ZkCli, zkWatcher *ZkWatcherMan) (*SolrMonitor, error) {
-	return NewSolrMonitorWithLogger(zkCli, zkWatcher, zk.DefaultLogger, []string{sysColPrefix}, []string{"_as"}, nil) //this is not great, ignoring _as suffix is specific to us
+func NewSolrMonitor(zkCli ZkCli, ignoreSuffixes []string, zkWatcher *ZkWatcherMan) (*SolrMonitor, error) {
+	return NewSolrMonitorWithLogger(zkCli, zkWatcher, zk.DefaultLogger, true, nil, nil) // ignore sys collections by default
 }
 
 // Create a new solrmonitor.  Solrmonitor takes ownership of the provided zkCli and zkWatcher-- they
 // will be closed when Solrmonitor is closed, and should not be used by any other caller.
 // The provided zkWatcher must already be wired to the associated zkCli to receive all global events.
-func NewSolrMonitorWithLogger(zkCli ZkCli, zkWatcher *ZkWatcherMan, logger zk.Logger, ignorePrefixes []string, ignoreSuffixes []string, solrEventListener SolrEventListener) (*SolrMonitor, error) {
+func NewSolrMonitorWithLogger(zkCli ZkCli, zkWatcher *ZkWatcherMan, logger zk.Logger, ignoreSysCol bool, ignoreSuffixes []string, solrEventListener SolrEventListener) (*SolrMonitor, error) {
+	var ignorePrefixes []string
+	if ignoreSysCol {
+		ignorePrefixes = []string{sysColPrefix}
+	}
 	return NewSolrMonitorWithRoot(zkCli, zkWatcher, logger, "/solr", ignorePrefixes, ignoreSuffixes, solrEventListener)
 }
 


### PR DESCRIPTION
## Description
In our usage, there are solr collections with certain suffixes that we want to ignore by SolrMonitor

## Solution
Similar to a previous feature to ignore system collections, we added another param `ignoreSuffixes` for `SolrMonitor` instantiation. Adjusted signatures accordingly.