### PR TITLE
move thrashing fix

### DIFF
--- a/solrman/smmodel/model.go
+++ b/solrman/smmodel/model.go
@@ -218,9 +218,9 @@ func (m *Model) computeNextMove(immobileCores []bool) *Move {
 					continue
 				}
 
-				// If the source is substantially under the maximum size, only move if the target node is substantially smaller than the source node.
+				// If the source is substantially under the maximum size (<10%), only move if the target node is substantially smaller than the source node.
 				// This is to avoid move thrashing in a cluster that is drastically below capacity while nodes are rapidly growing.
-				if source.Size < 10*source.MaxSize && target.Size+5*core.Size >= source.Size {
+				if source.Size*10 < source.MaxSize && target.Size+5*core.Size >= source.Size {
 					continue
 				}
 


### PR DESCRIPTION
This PR fixes a bug in the move thrashing algorithm.

The intention of the code is to not move shards from nodes that are <10% the max size of the node. This was being calculated incorrectly as `size < 10 * maxSize`, when it should have been `size < .1 * maxSize`. I accomplish this by doing `size * 10 < maxSize`, which is the same calculation in integer format. 

This PR also adds a test for this case. 