### PR TITLE
SAI-5883: Auto move balance model tweaks

### DIFF
--- a/solrman/smmodel/collection.go
+++ b/solrman/smmodel/collection.go
@@ -96,11 +96,15 @@ func (c *Collection) balance(nodeCount int) balanceInfo {
 			coresPerNode[core.nodeId]++
 		}
 
-		// sum of squares, 10 extra cores on one machine is way worse than 1 extra core on 10 machines.
+		// scoring - higher scores mean better candidate for moves, add score if:
+		// 1. node's core count is higher than the ideal maxCoresPerNode. Square here, as 10 extra cores on one machine is way worse than 1 extra core on 10 machines.
+		// 2. node has fewer cores than ideal maxCoresPerNode, and the delta is at least 2. Using square to amplify deviation similar to point 1
 		var score int64
 		for _, v := range coresPerNode {
 			if v > maxCoresPerNode {
 				score += int64((v - maxCoresPerNode) * (v - maxCoresPerNode))
+			} else if v < maxCoresPerNode-1 { //+ score if there are many nodes with very few cores
+				score += int64((v - (maxCoresPerNode - 1)) * (v - (maxCoresPerNode - 1)))
 			}
 		}
 

--- a/solrman/smmodel/model.go
+++ b/solrman/smmodel/model.go
@@ -218,7 +218,6 @@ func (m *Model) computeNextMove(immobileCores []bool) (*Move, string) {
 				//Make sure it would not violate balance per collection ie target and source node would not have core
 				//per collection delta >= 2 after the move
 				if coll.balanceInfo.coresPerNode[target.id] >= coll.balanceInfo.coresPerNode[source.id] {
-					fmt.Printf("Skipping %s as collection %s already has %d cores on source and %d cores on target", target.Name, coll.Name, coll.balanceInfo.coresPerNode[source.id], coll.balanceInfo.coresPerNode[target.id])
 					continue
 				}
 

--- a/solrman/smmodel/model.go
+++ b/solrman/smmodel/model.go
@@ -312,8 +312,28 @@ func (m *Model) computeNextMove(immobileCores []bool) (*Move, string) {
 	// Step 3: balance nodes next, respecting collection balance.
 	// Take the largest core from the largest node, and move it to the smallest node, provided we don't violate constraints.
 	if len(nodesBySize) > 1 {
-		biggest := nodesBySize[len(nodesBySize)-1]
-		return tryMoveCoreFrom(biggest, false)
+		firstReason := ""
+		lastReason := ""
+		//try to move from the higher half nodes
+		for i := 1; i <= len(nodesBySize)/2; i++ {
+			fromNode := nodesBySize[len(nodesBySize)-i]
+			move, reason := tryMoveCoreFrom(fromNode, false)
+			if i == 1 {
+				firstReason = reason //first reason has some significance, why the node with highest usage cannot generate any moves
+			}
+			lastReason = reason
+			if move != nil { //found a valid move
+				return move, ""
+			}
+		}
+		var finalReason string
+		if firstReason != lastReason {
+			finalReason = fmt.Sprintf("First Reason: %s, Last Reason: %s", firstReason, lastReason)
+		} else {
+			finalReason = lastReason
+		}
+
+		return nil, finalReason //no valid moves from the higher half nodes, return the reason of first and last iteration
 	}
 
 	return nil, "nodesBySize is <= 1"

--- a/solrman/smmodel/model.go
+++ b/solrman/smmodel/model.go
@@ -19,6 +19,8 @@ import (
 	"sort"
 )
 
+const noFurtherMoves = "No further moves found after iterating all the cores and nodes"
+
 type Model struct {
 	Nodes       []*Node       `json:"nodes"`
 	Collections []*Collection `json:"collections"`
@@ -108,10 +110,10 @@ func (m *Model) WithMove(move Move) *Model {
 	}
 }
 
-func (m *Model) computeNextMove(immobileCores []bool) *Move {
+func (m *Model) computeNextMove(immobileCores []bool) (*Move, string) {
 	if len(m.Nodes) < 2 || len(m.Cores) < 1 {
 		// can't balance a single-node or empty cluster
-		return nil
+		return nil, "No balance on singe-node/empty cluster"
 	}
 
 	// Compute balance info.
@@ -157,7 +159,7 @@ func (m *Model) computeNextMove(immobileCores []bool) *Move {
 				Core:     core,
 				FromNode: from,
 				ToNode:   to,
-			}
+			}, ""
 		}
 	}
 
@@ -168,7 +170,7 @@ func (m *Model) computeNextMove(immobileCores []bool) *Move {
 	})
 
 	// Try to move a core from the given node.
-	tryMoveCoreFrom := func(source *Node, force bool) *Move {
+	tryMoveCoreFrom := func(source *Node, force bool) (*Move, string) {
 		for _, target := range nodesBySize {
 			if target == source {
 				continue
@@ -195,12 +197,12 @@ func (m *Model) computeNextMove(immobileCores []bool) *Move {
 					Core:     candidates[0],
 					FromNode: source,
 					ToNode:   target,
-				}
+				}, ""
 			}
 
-			if 9*source.Size < 10*target.Size {
-				// if the target node is >=90% of the source node, don't bother
-				return nil
+			if target.Size > int64(float64(source.Size)*0.99) {
+				// if the target node is > 99% of the source node, don't bother
+				return nil, fmt.Sprintf("Target node %s with size %d is already > 99%% of source node %s with size %d", target.Name, target.Size, source.Name, source.Size)
 			}
 
 			for _, core := range candidates {
@@ -210,6 +212,13 @@ func (m *Model) computeNextMove(immobileCores []bool) *Move {
 				// Make sure moving this core won't violate collection balance.
 				coll := m.Collections[core.collectionId]
 				if coll.balanceInfo.coresPerNode[target.id] >= coll.balanceInfo.maxCoresPerNode {
+					continue
+				}
+
+				//Make sure it would not violate balance per collection ie target and source node would not have core
+				//per collection delta >= 2 after the move
+				if coll.balanceInfo.coresPerNode[target.id] >= coll.balanceInfo.coresPerNode[source.id] {
+					fmt.Printf("Skipping %s as collection %s already has %d cores on source and %d cores on target", target.Name, coll.Name, coll.balanceInfo.coresPerNode[source.id], coll.balanceInfo.coresPerNode[target.id])
 					continue
 				}
 
@@ -229,10 +238,10 @@ func (m *Model) computeNextMove(immobileCores []bool) *Move {
 					Core:     core,
 					FromNode: source,
 					ToNode:   target,
-				}
+				}, ""
 			}
 		}
-		return nil
+		return nil, noFurtherMoves
 	}
 
 	// Step 2: balance collections next, respecting node max size.
@@ -297,7 +306,7 @@ func (m *Model) computeNextMove(immobileCores []bool) *Move {
 				Core:     core,
 				FromNode: fromNode,
 				ToNode:   target,
-			}
+			}, ""
 		}
 	}
 
@@ -305,22 +314,22 @@ func (m *Model) computeNextMove(immobileCores []bool) *Move {
 	// Take the largest core from the largest node, and move it to the smallest node, provided we don't violate constraints.
 	if len(nodesBySize) > 1 {
 		biggest := nodesBySize[len(nodesBySize)-1]
-		m := tryMoveCoreFrom(biggest, false)
-		if m != nil {
-			return m
-		}
+		return tryMoveCoreFrom(biggest, false)
 	}
 
-	return nil
+	return nil, "nodesBySize is <= 1"
 }
 
-func (m *Model) ComputeBestMoves(count int) []Move {
+func (m *Model) ComputeBestMoves(count int) ([]Move, string) {
 	var moves []Move
 
 	curModel := m
 	immobileCores := make([]bool, len(m.Cores)) // cores that have already moved
+
+	reason := "" //reason of why there's no more good moves
 	for i := 0; i < count; i++ {
-		move := curModel.computeNextMove(immobileCores)
+		var move *Move
+		move, reason = curModel.computeNextMove(immobileCores)
 		if move == nil {
 			// no good moves
 			break
@@ -330,5 +339,5 @@ func (m *Model) ComputeBestMoves(count int) []Move {
 		curModel = curModel.WithMove(*move)
 	}
 
-	return moves
+	return moves, reason
 }

--- a/solrman/smmodel/model.go
+++ b/solrman/smmodel/model.go
@@ -122,7 +122,11 @@ func (m *Model) computeNextMove(immobileCores []bool) (*Move, string) {
 		balanceInfo = append(balanceInfo, c.balance(len(m.Nodes)))
 	}
 	sort.Slice(balanceInfo, func(i, j int) bool {
-		return balanceInfo[i].score > balanceInfo[j].score
+		if balanceInfo[i].score != balanceInfo[j].score {
+			return balanceInfo[i].score > balanceInfo[j].score
+		} else {
+			return balanceInfo[i].coll.Name < balanceInfo[j].coll.Name
+		}
 	})
 
 	// Step 1: remove duplicate replicas

--- a/solrman/smmodel/model_test.go
+++ b/solrman/smmodel/model_test.go
@@ -24,56 +24,64 @@ import (
 func TestEmptyModel(t *testing.T) {
 	t.Parallel()
 	m := &Model{}
-	moves := m.ComputeBestMoves(1)
+	moves, reason := m.ComputeBestMoves(1)
 	if len(moves) != 0 {
 		t.Errorf("Expected no moves")
 	}
+	assertString(t, "No balance on singe-node/empty cluster", reason)
 }
 
 func TestTinyModel(t *testing.T) {
 	t.Parallel()
 	m := createTestModel(tinyModel)
-	moves := m.ComputeBestMoves(1)
+	moves, reason := m.ComputeBestMoves(1)
 	if len(moves) != 0 {
 		t.Errorf("Expected no moves")
 	}
+
+	assertString(t, noFurtherMoves, reason)
 }
 
 func TestSmallModel(t *testing.T) {
 	t.Parallel()
 	m := createTestModel(smallModel)
-	moves := m.ComputeBestMoves(3)
+	moves, reason := m.ComputeBestMoves(3)
 	assertEquals(t, []string{
 		`{"core":"A_shard1_0_replica2","collection":"A","shard":"shard1_0","from_node":"solr-1.node","to_node":"solr-2.node"}`,
 	}, moves)
+
+	assertString(t, noFurtherMoves, reason)
 }
 
 func TestDeletesExtraReplicas(t *testing.T) {
 	t.Parallel()
 	m := createTestModel(extraReplicaModel)
-	moves := m.ComputeBestMoves(3)
+	moves, reason := m.ComputeBestMoves(3)
 	assertEquals(t, []string{
 		`{"core":"A_shard1_replica1","collection":"A","shard":"shard1","from_node":"solr-2.node","to_node":"solr-1.node"}`,
 	}, moves)
+	assertString(t, noFurtherMoves, reason)
 }
 
 func TestCollectionBalanceModel(t *testing.T) {
 	t.Parallel()
 	m := createTestModel(collectionBalanceModel)
-	moves := m.ComputeBestMoves(3)
+	moves, reason := m.ComputeBestMoves(3)
 
 	if len(moves) != 0 {
 		t.Errorf("Should not have any move")
 	}
+	assertString(t, noFurtherMoves, reason)
 }
 
 func TestThrashingModel(t *testing.T) {
 	t.Parallel()
 	m := createTestModel(thrashingModel)
-	moves := m.ComputeBestMoves(1)
+	moves, reason := m.ComputeBestMoves(1)
 	if len(moves) != 0 {
 		t.Errorf("Should not have any moves")
 	}
+	assertString(t, noFurtherMoves, reason)
 }
 
 func TestLargeModel(t *testing.T) {
@@ -85,14 +93,28 @@ func TestLargeModel(t *testing.T) {
 
 	// TODO(jh): review results
 	m := createTestModel(string(data))
-	moves := m.ComputeBestMoves(5)
+	moves, reason := m.ComputeBestMoves(5)
 	assertEquals(t, []string{
 		`{"core":"collD_shard1_0_0_0_replica1","collection":"collD","shard":"shard1_0_0_0","from_node":"solr-1.node","to_node":"solr-6.node"}`,
 		`{"core":"collD_shard1_0_0_1_replica1","collection":"collD","shard":"shard1_0_0_1","from_node":"solr-1.node","to_node":"solr-9.node"}`,
 		`{"core":"collD_shard1_0_1_0_replica1","collection":"collD","shard":"shard1_0_1_0","from_node":"solr-1.node","to_node":"solr-7.node"}`,
 		`{"core":"coll3F_shard1_0_0_0_replica1","collection":"coll3F","shard":"shard1_0_0_0","from_node":"solr-1.node","to_node":"solr-6.node"}`,
-		`{"core":"coll8A_shard1_0_1_0_replica1","collection":"coll8A","shard":"shard1_0_1_0","from_node":"solr-4.node","to_node":"solr-6.node"}`,
+		`{"core":"coll15_shard1_0_0_0_0_0_replica1","collection":"coll15","shard":"shard1_0_0_0_0_0","from_node":"solr-1.node","to_node":"solr-6.node"}`,
 	}, moves)
+
+	assertString(t, "", reason) //no reason as there are 5 moves as desired
+}
+
+func TestStorageModel(t *testing.T) {
+	t.Parallel()
+	m := createTestModel(storageModel)
+	moves, reason := m.ComputeBestMoves(2)
+
+	assertEquals(t, []string{
+		`{"core":"A_shard1_replica1","collection":"A","shard":"shard1","from_node":"solr-1.node","to_node":"solr-2.node"}`,
+		`{"core":"B_shard1_replica1","collection":"B","shard":"shard1","from_node":"solr-2.node","to_node":"solr-1.node"}`,
+	}, moves)
+	assertString(t, "", reason) //no reason as there are 2 moves as desired
 }
 
 func assertEquals(t *testing.T, expected []string, actual []Move) {
@@ -105,6 +127,12 @@ func assertEquals(t *testing.T, expected []string, actual []Move) {
 		} else if actual[i].String() != expected[i] {
 			t.Errorf("at index: %d\nexpected: %s\n  actual: %s", i, expected[i], &actual[i])
 		}
+	}
+}
+
+func assertString(t *testing.T, expected string, actual string) {
+	if expected != actual {
+		t.Errorf("Expected %s but found %s", expected, actual)
 	}
 }
 
@@ -272,5 +300,19 @@ const (
 		"A_shard2_replica3,15.0M,3.0GB\n" +
 		"solr-2.node,2.2.2.2:8983_solr\n" +
 		"A_shard4_replica5,15.0M,8.0GB\n" +
+		""
+
+	// Prioritize collection balance first (step 2)
+	// Node space step (step 3) should NOT violate collection balance
+	// hence it should NOT move A back from node 2 to 1, instead it should move B to node 1
+	//
+	storageModel = "" +
+		"solr-1.node,1.1.1.1:8983_solr\n" +
+		"A_shard1_replica1,5.0M,5.1GB\n" +
+		"A_shard2_replica1,5.0M,5.0GB\n" +
+		"A_shard3_replica1,5.0M,5.0GB\n" +
+		"solr-2.node,2.2.2.2:8983_solr\n" +
+		"A_shard4_replica1,10.0M,15.0GB\n" +
+		"B_shard1_replica1,1.0M,1.0GB\n" +
 		""
 )

--- a/solrman/smmodel/model_test.go
+++ b/solrman/smmodel/model_test.go
@@ -98,8 +98,8 @@ func TestLargeModel(t *testing.T) {
 		`{"core":"collD_shard1_0_0_0_replica1","collection":"collD","shard":"shard1_0_0_0","from_node":"solr-1.node","to_node":"solr-6.node"}`,
 		`{"core":"collD_shard1_0_0_1_replica1","collection":"collD","shard":"shard1_0_0_1","from_node":"solr-1.node","to_node":"solr-9.node"}`,
 		`{"core":"collD_shard1_0_1_0_replica1","collection":"collD","shard":"shard1_0_1_0","from_node":"solr-1.node","to_node":"solr-7.node"}`,
-		`{"core":"coll3F_shard1_0_0_0_replica1","collection":"coll3F","shard":"shard1_0_0_0","from_node":"solr-1.node","to_node":"solr-6.node"}`,
 		`{"core":"coll15_shard1_0_0_0_0_0_replica1","collection":"coll15","shard":"shard1_0_0_0_0_0","from_node":"solr-1.node","to_node":"solr-6.node"}`,
+		`{"core":"coll19_shard1_0_0_0_replica1","collection":"coll19","shard":"shard1_0_0_0","from_node":"solr-1.node","to_node":"solr-6.node"}`,
 	}, moves)
 
 	assertString(t, "", reason) //no reason as there are 5 moves as desired


### PR DESCRIPTION
## Description
1. Move computation step 2 (balance core # within a collection across nodes) only guarantees that no node is beyond “ideal max cores per node”. For example if total cores is 10, and  # of nodes is 4, then “ideal max cores per node” would be 3 (distribution of cores 2,2,3,3). However, it would NOT fix if the distribution is 1,3,3,3.
2. Move computation step 3 (balance among nodes) rejects any moves if the “from” node (node with least free space) and “to” node (node with most free space) have storage delta less than 10%
3. After changing step 1 to be more aggressive in balancing cores by ensuring no 2 nodes would have core # delta >= 2, step 3 make moves that conflict step 2
4. Mega shard could prevent the node with least free space from generating move from step 3. See remarks for details

## Solution
Various tweaks to the auto move balance model in gosolr:

1. More aggressive per collection balance (step 2) which only stop until all nodes have either the ideal max core per node or 1 less of it. This is done by adding scores to nodes with cores # <= "ideal max cores per node" - 2
2. Across node storage balance (step 3) will only short-cut out (no solution) if target node is 99% size of source node (instead of 90% before)
3. Across node storage balance (step 3) will NOT move a core if the resulting core per collection delta >= 2, to avoid conflicts with more aggressive balance change introduced by point 1
4. Move algorithm now return a "reason" string on why the returned moves are less than the `count` argument to `ComputeBestMoves`
5. Updated test cases to verify the above changes
6. Across node storage balance (step 3) try on the half highest nodes instead of only the top node. As doing it only on the top node could short-cut out all the time if it's affected by a mega shard. See remarks section for details
7. Fixed node balance info sorting to avoid unstable sorts

## Tests
1. Adjusted the current test cases as one failed due to a behavioral change (step 2 is more aggressive now)
2. Added one more test case to verify the behavioral change
3. This is actually deployed on prod eu1 with the new behaviors observed and verified


## Remarks
We have found that with point 2 set to 0.5%, the model still does not compute any moves even the max and min node storage used delta was around 1.5%. 

This was triggered by a mega shard on max usage node. Due to such shard taking more storage on this node, the other collections on the same node actually have relatively less cores. This forces step 3 to eventually bypass most of the "candidate move-to" node as moving any cores from the mega shard node could violate "cores per collection per node" balance.

The move algorithm could not really do much to handle such mega shard, it is already doing its best to move cores away from this node w/o violating per node core # balance.