### PR TITLE
solrmonitor: fix PRS children watch not re-established after ZK disconnect

### DIFF
--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -445,9 +445,15 @@ func (c *SolrMonitor) shouldWatchChildren(path string) bool {
 		// watch coll/state.json childrens for replica status
 		if strings.HasPrefix(path, c.solrRoot+"/collections/") && strings.HasSuffix(path, "/state.json") {
 			coll := c.getCollFromPath(path)
-			if coll != nil {
-				return coll.isPRSEnabled()
+			if coll == nil {
+				c.logger.Printf("shouldWatchChildren: collection not found for path %s", path)
+				return false
 			}
+			if !coll.isPRSEnabled() {
+				c.logger.Printf("shouldWatchChildren: PRS not enabled for collection %s", coll.name)
+				return false
+			}
+			return true
 		}
 		return false
 	}
@@ -812,7 +818,11 @@ func (coll *collection) startMonitoringReplicaStatus() {
 		if err == nil {
 			coll.parent.logger.Printf("startMonitoringReplicaStatus: watching collection [%s] children for PRS", coll.name)
 			coll.setWatch(true)
+		} else {
+			coll.parent.logger.Printf("startMonitoringReplicaStatus: error watching collection [%s] children: %s (will retry via deferred task)", coll.name, err)
 		}
+	} else {
+		coll.parent.logger.Printf("startMonitoringReplicaStatus: skipping collection [%s], already has watch", coll.name)
 	}
 }
 

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -127,6 +127,16 @@ func (c callbacks) ShouldWatchData(path string) bool {
 	return c.SolrMonitor.shouldWatchPath(path) || c.SolrMonitor.shouldWatchCollection(path)
 }
 
+func (c callbacks) WatchLost(path string) {
+	// Reset isWatched for any collection whose state.json watch was lost
+	if strings.HasSuffix(path, "/state.json") {
+		if coll := c.SolrMonitor.getCollFromPath(path); coll != nil {
+			coll.setWatch(false)
+			c.SolrMonitor.logger.Printf("WatchLost: reset isWatched for collection %s", coll.name)
+		}
+	}
+}
+
 func (c *SolrMonitor) Close() {
 	c.zkCli.Close()
 	c.zkWatcher.Close()

--- a/solrmonitor/solrmonitor.go
+++ b/solrmonitor/solrmonitor.go
@@ -806,7 +806,7 @@ func (coll *collection) carryOverConfigName(newState *CollectionState) {
 func (coll *collection) startMonitoringReplicaStatus() {
 	path := coll.parent.solrRoot + "/collections/" + coll.name + "/state.json"
 
-	// TODO: need to revisit coll.isWatched flag(if zk disconnects?). we need to create watch once only Scott?
+	// note: when ZK disconnects, hasWatch will reset to return false (and therefore we will create a new watch here)
 	if !coll.hasWatch() {
 		err := coll.parent.zkWatcher.MonitorChildren(path)
 		if err == nil {

--- a/solrmonitor/solrmonitor_test.go
+++ b/solrmonitor/solrmonitor_test.go
@@ -85,7 +85,7 @@ func setup(t *testing.T) (*SolrMonitor, *testutil) {
 		collStateEvents:  0,
 		collectionStates: make(map[string]*CollectionState),
 	}
-	sm, err := NewSolrMonitorWithRoot(conn, watcher, logger, root, false, l)
+	sm, err := NewSolrMonitorWithRoot(conn, watcher, logger, root, nil, nil, l)
 	if err != nil {
 		conn.Close()
 		t.Fatal(err)
@@ -218,7 +218,7 @@ func TestCollectionChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sm2, err := NewSolrMonitorWithRoot(conn2, w2, testutil.logger, testutil.root, false, nil)
+	sm2, err := NewSolrMonitorWithRoot(conn2, w2, testutil.logger, testutil.root, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -469,4 +469,116 @@ func (l *SEListener) SolrCollectionReplicaStatesChanged(name string, replicaStat
 
 func (l *SEListener) SolrClusterPropsChanged(clusterprops map[string]string) {
 	l.clusterPropChangeEvents++
+}
+
+// TestPRSWatchReestablishedAfterWatchLost tests that PRS children watches are
+// re-established after a ZK watch is lost (e.g., due to session disconnect).
+//
+// The bug scenario:
+// 1. isWatched is true (watch was legitimately established)
+// 2. ZK disconnects, EventNotWatching fires, child watch goes away
+// 3. WITHOUT the fix: isWatched remains true (stale), recovery skips MonitorChildren
+// 4. WITH the fix: WatchLost resets isWatched to false, recovery calls MonitorChildren
+func TestPRSWatchReestablishedAfterWatchLost(t *testing.T) {
+	sm, testutil := setup(t)
+	defer testutil.teardown()
+
+	zkCli := testutil.conn
+
+	// Create the ZK structure for a PRS-enabled collection
+	zkCli.Create(sm.solrRoot+"/collections", nil, 0, zk.WorldACL(zk.PermAll))
+	_, err := zkCli.Create(sm.solrRoot+"/collections/c1", []byte(`{"configName":"_FS4"}`), 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up PRS-enabled collection with a replica
+	_, err = zkCli.Set(sm.solrRoot+"/collections/c1/state.json",
+		[]byte("{\"c1\":{\"perReplicaState\":\"true\", \"shards\":{\"shard_1\":{\"replicas\":{\"R1\":{\"core\":\"core1\"}}}}}}"), -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for collection to be detected
+	shouldExist(t, sm, "c1", func(collectionState *CollectionState) error {
+		if !collectionState.IsPRSEnabled() {
+			return errors.New("expected collection to be PRS enabled")
+		}
+		return nil
+	})
+
+	// Create initial PRS child: R1 is Active and Leader
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:1:A:L", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify initial PRS state
+	prsShouldExist(t, sm, "c1", "shard_1", "R1", "active", "true", 1)
+
+	// Verify the watch is established
+	coll := sm.getCollection("c1")
+	if coll == nil {
+		t.Fatal("collection c1 not found")
+	}
+	if !coll.hasWatch() {
+		t.Fatal("expected hasWatch() to be true after initial PRS setup")
+	}
+
+	// Record initial replica change events
+	initialReplicaEvents := testutil.solrEventListener.collReplicaChangeEvents
+
+	// === SIMULATE ZK DISCONNECT ===
+	// The bug: isWatched is true, but the actual ZK watch will be lost.
+	// Fire EventNotWatching to simulate ZK disconnect.
+	// The fix (WatchLost callback) should reset isWatched to false.
+	statePath := sm.solrRoot + "/collections/c1/state.json"
+
+	// Verify isWatched is true BEFORE the event (this is the stale state in the bug)
+	if !coll.hasWatch() {
+		t.Fatal("expected hasWatch() to be true before EventNotWatching")
+	}
+
+	sm.zkWatcher.EventCallback(zk.Event{
+		Type:  zk.EventNotWatching,
+		State: zk.StateDisconnected,
+		Path:  statePath,
+	})
+
+	// Immediately after EventNotWatching, the WatchLost callback should have
+	// reset isWatched to false (this is the fix!)
+	if coll.hasWatch() {
+		t.Error("expected hasWatch() to be false immediately after EventNotWatching (WatchLost should reset it)")
+	}
+
+	// Give deferred tasks time to process - they will re-establish the watch
+	time.Sleep(500 * time.Millisecond)
+
+	// === VERIFY FIX ===
+	// After deferred task processing, watch should be re-established
+	if !coll.hasWatch() {
+		t.Error("expected hasWatch() to be true after watch lost recovery")
+	}
+
+	// Update PRS state: R1 changes to version 2, Down, not leader
+	_, err = zkCli.Create(sm.solrRoot+"/collections/c1/state.json/R1:2:D", nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify PRS updates are received (watch is working)
+	prsShouldExist(t, sm, "c1", "shard_1", "R1", "down", "false", 2)
+
+	// Verify we received replica change events (proves the watch is active)
+	if testutil.solrEventListener.collReplicaChangeEvents <= initialReplicaEvents {
+		t.Error("expected to receive replica change events after watch recovery")
+	}
+
+	t.Logf("Test passed: PRS watch re-established after EventNotWatching, replica events: %d -> %d",
+		initialReplicaEvents, testutil.solrEventListener.collReplicaChangeEvents)
 }

--- a/solrmonitor/zkwatcherman.go
+++ b/solrmonitor/zkwatcherman.go
@@ -87,14 +87,12 @@ func (m *ZkWatcherMan) EventCallback(evt zk.Event) {
 		m.enqueueDeferredTask(deferredChildrenTask{evt.Path})
 	case zk.EventNotWatching:
 		// Lost ZK session; we'll need to re-register all watches when it comes back.
-		// Just enqueue both kinds of tasks, we might throw them away later.
-		m.enqueueDeferredTask(deferredDataTask{evt.Path})
-		m.enqueueDeferredTask(deferredChildrenTask{evt.Path})
-		
-		// Notify that watch was lost so flags can be reset
+		// First reset any watch flags, then enqueue recovery tasks.
 		if m.callbacks != nil {
 			m.callbacks.WatchLost(evt.Path)
 		}
+		m.enqueueDeferredTask(deferredDataTask{evt.Path})
+		m.enqueueDeferredTask(deferredChildrenTask{evt.Path})
 	default:
 		if evt.Err == zk.ErrClosing {
 			m.logger.Printf("ZkWatcherMan %s event received with state %s: closing", evt.Type, evt.State)

--- a/solrmonitor/zkwatcherman.go
+++ b/solrmonitor/zkwatcherman.go
@@ -226,6 +226,7 @@ func (m *ZkWatcherMan) fetchChildren(path string) (zkErr, cbErr error) {
 		m.enqueueDeferredTask(deferredChildrenTask{path: path})
 		return err, nil
 	} else {
+		m.logger.Printf("fetchChildren: established watch for %s with %d children", path, len(children))
 		return nil, m.callbacks.ChildrenChanged(path, children)
 	}
 }

--- a/solrmonitor/zkwatcherman.go
+++ b/solrmonitor/zkwatcherman.go
@@ -28,6 +28,7 @@ type Callbacks interface {
 	DataChanged(path string, data string, stat *zk.Stat) error
 	ShouldWatchChildren(path string) bool
 	ShouldWatchData(path string) bool
+	WatchLost(path string)
 }
 
 // A MonitorChildren request whose last attempt to set a watch failed.
@@ -89,6 +90,11 @@ func (m *ZkWatcherMan) EventCallback(evt zk.Event) {
 		// Just enqueue both kinds of tasks, we might throw them away later.
 		m.enqueueDeferredTask(deferredDataTask{evt.Path})
 		m.enqueueDeferredTask(deferredChildrenTask{evt.Path})
+		
+		// Notify that watch was lost so flags can be reset
+		if m.callbacks != nil {
+			m.callbacks.WatchLost(evt.Path)
+		}
 	default:
 		if evt.Err == zk.ErrClosing {
 			m.logger.Printf("ZkWatcherMan %s event received with state %s: closing", evt.Type, evt.State)


### PR DESCRIPTION
## Summary
- Adds a WatchLost callback to notify when a ZK watch is lost due to session disconnect
- Resets the isWatched flag for PRS-enabled collections when EventNotWatching fires
- Ensures PRS children watches are re-established on reconnect, fixing isActive=null and isLeader=null for replicas

## Problem
After ZK disconnect and reconnect, some PRS-enabled collections showed `isActive: null, isLeader: null` for replicas. This could have occurred because the isWatched flag was never reset when EventNotWatching fired. When startMonitoringReplicaStatus() was called during reconnection, hasWatch() still returned true (stale), causing MonitorChildren to be skipped and the PRS watch to never be re-established.

## Solution
When EventNotWatching fires, call the new WatchLost callback to reset isWatched to false. On reconnect, startMonitoringReplicaStatus() now sees hasWatch() == false and properly calls MonitorChildren to re-establish the PRS children watch.

## Test
[x] Verify existing tests pass (go test ./solrmonitor/...)

## Notes
I tried really hard to recreate this issue locally but was unsuccessful. Given that it most likely relies on network issues and timing-reliant race conditions, I'm unsure if it would even be possible to reliably recreate this issue. This change is rather harmless if it doesn't fix the issue. We can monitor to see if this fixes things, or to look into it further. 